### PR TITLE
feat: 캠페인 등록 API 개발

### DIFF
--- a/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
@@ -1,0 +1,28 @@
+package cholog.wiseshop.api.campaign.controller;
+
+import cholog.wiseshop.api.campaign.dto.CreateCampaignRequest;
+import cholog.wiseshop.api.campaign.service.CampaignService;
+import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class CampaignController {
+
+    private final CampaignService campaignService;
+
+    public CampaignController(CampaignService campaignService) {
+        this.campaignService = campaignService;
+    }
+
+    @PostMapping("/campaigns")
+    public ResponseEntity<Long> createCampaigns(@RequestBody CreateCampaignRequest request) {
+        Long productId = campaignService.createCampaign(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(productId);
+    }
+}

--- a/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
@@ -1,10 +1,12 @@
 package cholog.wiseshop.api.campaign.controller;
 
-import cholog.wiseshop.api.campaign.dto.CreateCampaignRequest;
+import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
+import cholog.wiseshop.api.campaign.dto.response.ReadCampaignResponse;
 import cholog.wiseshop.api.campaign.service.CampaignService;
-import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,5 +26,11 @@ public class CampaignController {
     public ResponseEntity<Long> createCampaigns(@RequestBody CreateCampaignRequest request) {
         Long productId = campaignService.createCampaign(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(productId);
+    }
+
+    @GetMapping("/campaigns/{id}")
+    public ResponseEntity<ReadCampaignResponse> readCampaign(@PathVariable Long id) {
+        ReadCampaignResponse response = campaignService.readCampaign(id);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/dto/CreateCampaignRequest.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/dto/CreateCampaignRequest.java
@@ -1,0 +1,9 @@
+package cholog.wiseshop.api.campaign.dto;
+
+import java.time.LocalDateTime;
+
+public record CreateCampaignRequest(LocalDateTime startDate,
+                                    LocalDateTime endDate,
+                                    int goalQuantity,
+                                    Long productId) {
+}

--- a/src/main/java/cholog/wiseshop/api/campaign/dto/CreateCampaignRequest.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/dto/CreateCampaignRequest.java
@@ -1,9 +1,14 @@
 package cholog.wiseshop.api.campaign.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import java.time.LocalDateTime;
 
-public record CreateCampaignRequest(LocalDateTime startDate,
-                                    LocalDateTime endDate,
-                                    int goalQuantity,
-                                    Long productId) {
+public record CreateCampaignRequest(
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        LocalDateTime startDate,
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        LocalDateTime endDate,
+        int goalQuantity,
+        Long productId) {
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/dto/request/CreateCampaignRequest.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/dto/request/CreateCampaignRequest.java
@@ -1,4 +1,4 @@
-package cholog.wiseshop.api.campaign.dto;
+package cholog.wiseshop.api.campaign.dto.request;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;

--- a/src/main/java/cholog/wiseshop/api/campaign/dto/response/ReadCampaignResponse.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/dto/response/ReadCampaignResponse.java
@@ -1,0 +1,5 @@
+package cholog.wiseshop.api.campaign.dto.response;
+
+public record ReadCampaignResponse(Long campaignId,
+                                   Long productId) {
+}

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -1,0 +1,28 @@
+package cholog.wiseshop.api.campaign.service;
+
+import cholog.wiseshop.api.campaign.dto.CreateCampaignRequest;
+import cholog.wiseshop.db.campaign.Campaign;
+import cholog.wiseshop.db.campaign.CampaignRepository;
+import cholog.wiseshop.db.product.Product;
+import cholog.wiseshop.db.product.ProductRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CampaignService {
+
+    private final CampaignRepository campaignRepository;
+    private final ProductRepository productRepository;
+
+    public CampaignService(CampaignRepository campaignRepository, ProductRepository productRepository) {
+        this.campaignRepository = campaignRepository;
+        this.productRepository = productRepository;
+    }
+
+    public Long createCampaign(CreateCampaignRequest request) {
+        Product findProduct = productRepository.findById(request.productId())
+                .orElseThrow(() -> new IllegalArgumentException("상품이 존재하지 않습니다."));
+        Campaign savedCampaign = campaignRepository.save(
+                new Campaign(findProduct, request.startDate(), request.endDate(), request.goalQuantity()));
+        return savedCampaign.getId();
+    }
+}

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -1,13 +1,16 @@
 package cholog.wiseshop.api.campaign.service;
 
-import cholog.wiseshop.api.campaign.dto.CreateCampaignRequest;
+import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
+import cholog.wiseshop.api.campaign.dto.response.ReadCampaignResponse;
 import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class CampaignService {
 
     private final CampaignRepository campaignRepository;
@@ -24,5 +27,12 @@ public class CampaignService {
         Campaign savedCampaign = campaignRepository.save(
                 new Campaign(findProduct, request.startDate(), request.endDate(), request.goalQuantity()));
         return savedCampaign.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public ReadCampaignResponse readCampaign(Long id) {
+        Campaign findCampaign = campaignRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("캠페인이 존재하지 않습니다."));
+        return new ReadCampaignResponse(findCampaign.getId(), findCampaign.getProduct().getId());
     }
 }

--- a/src/main/java/cholog/wiseshop/common/config/ModuleConfig.java
+++ b/src/main/java/cholog/wiseshop/common/config/ModuleConfig.java
@@ -1,0 +1,17 @@
+package cholog.wiseshop.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ModuleConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
+    }
+}

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -1,0 +1,62 @@
+package cholog.wiseshop.db.campaign;
+
+import cholog.wiseshop.db.product.Product;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
+
+@Entity
+public class Campaign {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "PRODUCT_ID")
+    private Product product;
+
+    private LocalDateTime startDate;
+
+    private LocalDateTime endDate;
+
+    private int goalQuantity;
+
+    private int soldQuantity;
+
+    private CampaignState state;
+
+    public Campaign(Product product, LocalDateTime startDate, LocalDateTime endDate, int goalQuantity) {
+        this.product = product;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.goalQuantity = goalQuantity;
+    }
+
+    public Campaign() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+
+    public LocalDateTime getStartDate() {
+        return startDate;
+    }
+
+    public LocalDateTime getEndDate() {
+        return endDate;
+    }
+
+    public int getGoalQuantity() {
+        return goalQuantity;
+    }
+}

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -1,6 +1,10 @@
 package cholog.wiseshop.db.campaign;
 
 import cholog.wiseshop.db.product.Product;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -20,8 +24,12 @@ public class Campaign {
     @JoinColumn(name = "PRODUCT_ID")
     private Product product;
 
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime startDate;
 
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime endDate;
 
     private int goalQuantity;

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -43,6 +43,7 @@ public class Campaign {
         this.startDate = startDate;
         this.endDate = endDate;
         this.goalQuantity = goalQuantity;
+        this.state = CampaignState.WAITING;
     }
 
     public Campaign() {
@@ -66,5 +67,9 @@ public class Campaign {
 
     public int getGoalQuantity() {
         return goalQuantity;
+    }
+
+    public CampaignState getState() {
+        return state;
     }
 }

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -20,7 +21,7 @@ public class Campaign {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "PRODUCT_ID")
     private Product product;
 

--- a/src/main/java/cholog/wiseshop/db/campaign/CampaignRepository.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/CampaignRepository.java
@@ -1,0 +1,6 @@
+package cholog.wiseshop.db.campaign;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CampaignRepository extends JpaRepository<Campaign, Long> {
+}

--- a/src/main/java/cholog/wiseshop/db/campaign/CampaignState.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/CampaignState.java
@@ -1,0 +1,9 @@
+package cholog.wiseshop.db.campaign;
+
+public enum CampaignState {
+
+    WAITING,
+    IN_PROGRESS,
+    FAILED,
+    SUCCESS;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,4 +17,4 @@ spring:
     properties:
       hibernate:
         show_sql: true
-        format_sql: true
+        format_sql:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,4 +17,4 @@ spring:
     properties:
       hibernate:
         show_sql: true
-        format_sql:
+        format_sql: true

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -101,4 +101,27 @@ public class CampaignServiceTest {
         assertThat(response.campaignId()).isEqualTo(campaignId);
         assertThat(response.productId()).isEqualTo(productId);
     }
+
+    @Test
+    void 캠페인_조회하기_예외_잘못된_캠페인ID() {
+        //given
+        String name = "보약";
+        String description = "먹으면 기분이 좋아져요.";
+        int price = 10000;
+        CreateProductRequest productRequest = new CreateProductRequest(name, description, price);
+        Long productId = productService.createProduct(productRequest);
+
+        //when
+        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+        int goalQuantity = 5;
+
+        Long campaignId = campaignService.createCampaign(
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
+        Long wrongId = campaignId + 1;
+
+        //then
+        assertThatThrownBy(() -> campaignService.readCampaign(wrongId))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
 }

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -9,6 +9,7 @@ import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.api.product.service.ProductService;
 import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.campaign.CampaignRepository;
+import cholog.wiseshop.db.campaign.CampaignState;
 import cholog.wiseshop.db.product.ProductRepository;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,6 +60,7 @@ public class CampaignServiceTest {
         assertThat(findCampaign.getStartDate().isEqual(startDate)).isTrue();
         assertThat(findCampaign.getEndDate().isEqual(endDate)).isTrue();
         assertThat(findCampaign.getGoalQuantity()).isEqualTo(goalQuantity);
+        assertThat(findCampaign.getState()).isEqualTo(CampaignState.WAITING);
     }
 
     @Test

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -1,0 +1,77 @@
+package cholog.wiseshop.domain.campaign;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import cholog.wiseshop.api.campaign.dto.CreateCampaignRequest;
+import cholog.wiseshop.api.campaign.service.CampaignService;
+import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
+import cholog.wiseshop.api.product.service.ProductService;
+import cholog.wiseshop.db.campaign.Campaign;
+import cholog.wiseshop.db.campaign.CampaignRepository;
+import cholog.wiseshop.db.product.ProductRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class CampaignServiceTest {
+
+    @Autowired
+    private CampaignService campaignService;
+
+    @Autowired
+    private CampaignRepository campaignRepository;
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @BeforeEach
+    public void cleanUp() {
+        productRepository.deleteAll();
+    }
+
+    @Test
+    void 캠페인_추가하기() {
+        //given
+        String name = "보약";
+        String description = "먹으면 기분이 좋아져요.";
+        int price = 10000;
+        CreateProductRequest productRequest = new CreateProductRequest(name, description, price);
+        Long productId = productService.createProduct(productRequest);
+
+        //when
+        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+        int goalQuantity = 5;
+
+        Long campaignId = campaignService.createCampaign(
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
+        Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
+
+        //then
+        assertThat(findCampaign.getProduct().getId()).isEqualTo(productId);
+        assertThat(findCampaign.getStartDate().isEqual(startDate)).isTrue();
+        assertThat(findCampaign.getEndDate().isEqual(endDate)).isTrue();
+        assertThat(findCampaign.getGoalQuantity()).isEqualTo(goalQuantity);
+    }
+
+    @Test
+    void 캠페인_추가하기_예외_잘못된_상품ID() {
+        //given
+        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+        int goalQuantity = 5;
+        Long productId = 1L;
+
+        //when & then
+        assertThatThrownBy(() -> campaignService.createCampaign(
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -3,7 +3,8 @@ package cholog.wiseshop.domain.campaign;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import cholog.wiseshop.api.campaign.dto.CreateCampaignRequest;
+import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
+import cholog.wiseshop.api.campaign.dto.response.ReadCampaignResponse;
 import cholog.wiseshop.api.campaign.service.CampaignService;
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.api.product.service.ProductService;
@@ -34,6 +35,7 @@ public class CampaignServiceTest {
 
     @BeforeEach
     public void cleanUp() {
+        campaignRepository.deleteAll();
         productRepository.deleteAll();
     }
 
@@ -75,5 +77,28 @@ public class CampaignServiceTest {
         assertThatThrownBy(() -> campaignService.createCampaign(
                 new CreateCampaignRequest(startDate, endDate, goalQuantity, productId)))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 캠페인_조회하기() {
+        //given
+        String name = "보약";
+        String description = "먹으면 기분이 좋아져요.";
+        int price = 10000;
+        CreateProductRequest productRequest = new CreateProductRequest(name, description, price);
+        Long productId = productService.createProduct(productRequest);
+
+        //when
+        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+        int goalQuantity = 5;
+
+        Long campaignId = campaignService.createCampaign(
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
+        ReadCampaignResponse response = campaignService.readCampaign(campaignId);
+
+        //then
+        assertThat(response.campaignId()).isEqualTo(campaignId);
+        assertThat(response.productId()).isEqualTo(productId);
     }
 }

--- a/src/test/java/cholog/wiseshop/web/campaign/CampaignControllerTest.java
+++ b/src/test/java/cholog/wiseshop/web/campaign/CampaignControllerTest.java
@@ -5,7 +5,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import cholog.wiseshop.api.campaign.dto.CreateCampaignRequest;
+import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
 import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;

--- a/src/test/java/cholog/wiseshop/web/campaign/CampaignControllerTest.java
+++ b/src/test/java/cholog/wiseshop/web/campaign/CampaignControllerTest.java
@@ -1,11 +1,14 @@
 package cholog.wiseshop.web.campaign;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
+import cholog.wiseshop.api.campaign.service.CampaignService;
 import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
@@ -34,6 +37,9 @@ public class CampaignControllerTest {
 
     @Autowired
     private CampaignRepository campaignRepository;
+
+    @Autowired
+    private CampaignService campaignService;
 
     @LocalServerPort
     private int port;
@@ -77,6 +83,33 @@ public class CampaignControllerTest {
                         .content(new ObjectMapper().writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(content().string("1"))
+                .andDo(print());
+    }
+
+    @Test
+    void 캠페인_조회하기() throws Exception {
+        // given
+        String name = "보약";
+        String description = "먹으면 기분이 좋아져요.";
+        int price = 10000;
+        Product product = new Product(name, description, price);
+        Product savedProduct = productRepository.save(product);
+
+        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+        int goalQuantity = 5;
+        CreateCampaignRequest request = new CreateCampaignRequest(
+                startDate, endDate, goalQuantity, savedProduct.getId());
+        Long campaignId = campaignService.createCampaign(request);
+
+        String url = "http://localhost:" + port + "/api/v1/campaigns/" + campaignId;
+
+        // when & then
+        mockMvc.perform(get(url)
+                        .characterEncoding("utf-8"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.campaignId").value(campaignId))
+                .andExpect(jsonPath("$.productId").value(savedProduct.getId()))
                 .andDo(print());
     }
 }

--- a/src/test/java/cholog/wiseshop/web/campaign/CampaignControllerTest.java
+++ b/src/test/java/cholog/wiseshop/web/campaign/CampaignControllerTest.java
@@ -1,0 +1,82 @@
+package cholog.wiseshop.web.campaign;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import cholog.wiseshop.api.campaign.dto.CreateCampaignRequest;
+import cholog.wiseshop.db.campaign.CampaignRepository;
+import cholog.wiseshop.db.product.Product;
+import cholog.wiseshop.db.product.ProductRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class CampaignControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private CampaignRepository campaignRepository;
+
+    @LocalServerPort
+    private int port;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setUp() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .build();
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        campaignRepository.deleteAll();
+        productRepository.deleteAll();
+    }
+
+    @Test
+    void 캠페인_생성하기() throws Exception {
+        // given
+        String name = "보약";
+        String description = "먹으면 기분이 좋아져요.";
+        int price = 10000;
+        Product product = new Product(name, description, price);
+        Product savedProduct = productRepository.save(product);
+
+        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+        int goalQuantity = 5;
+        CreateCampaignRequest request = new CreateCampaignRequest(
+                startDate, endDate, goalQuantity, savedProduct.getId());
+
+        String url = "http://localhost:" + port + "/api/v1/campaigns";
+
+        // when & then
+        mockMvc.perform(post(url)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(content().string("1"))
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
## 요약
- [1-make-product](https://github.com/cholog-project/wiseshop/tree/feature/1-make-product) 브랜치에서 개발을 시작하여 캠페인과 상품의 1대1 연관관계 추가 및 캠페인 등록 API 개발 및 테스트를 구현하였습니다.
- 변경사항을 확인하기 위해 `feature/1-make-product`를 PR 대상 브랜치로 지정하였습니다.

- 캠페인 조회 시, 상품도 함께 조회해야 하는 비즈니스 규약이 있기에 즉시 로딩 전략을 선택하였습니다.