### PR TITLE
feat: 캠페인 생성 시 스케줄 적용 및 테스트 동작 확인

### DIFF
--- a/src/main/java/cholog/wiseshop/WiseshopApplication.java
+++ b/src/main/java/cholog/wiseshop/WiseshopApplication.java
@@ -2,8 +2,10 @@ package cholog.wiseshop;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class WiseshopApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -7,11 +7,8 @@ import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.campaign.CampaignState;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.logging.Logger;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,16 +21,13 @@ public class CampaignService {
     private final CampaignRepository campaignRepository;
     private final ProductRepository productRepository;
     private final ThreadPoolTaskScheduler scheduler;
-    private final TransactionTemplate transactionTemplate;
 
     public CampaignService(CampaignRepository campaignRepository,
                            ProductRepository productRepository,
-                           ThreadPoolTaskScheduler scheduler,
-                           TransactionTemplate transactionTemplate) {
+                           ThreadPoolTaskScheduler scheduler) {
         this.campaignRepository = campaignRepository;
         this.productRepository = productRepository;
         this.scheduler = scheduler;
-        this.transactionTemplate = transactionTemplate;
     }
 
     public Long createCampaign(CreateCampaignRequest request) {

--- a/src/main/java/cholog/wiseshop/common/config/SchedulerConfig.java
+++ b/src/main/java/cholog/wiseshop/common/config/SchedulerConfig.java
@@ -1,0 +1,20 @@
+package cholog.wiseshop.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulerConfig {
+
+    @Bean
+    public ThreadPoolTaskScheduler threadPoolTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setThreadNamePrefix("campaign-scheduler");
+        scheduler.setPoolSize(10);
+        scheduler.setAwaitTerminationSeconds(60);
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -50,6 +50,10 @@ public class Campaign {
     public Campaign() {
     }
 
+    public void updateState(CampaignState state) {
+        this.state = state;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -136,7 +136,7 @@ public class CampaignServiceTest {
         Long productId = productService.createProduct(productRequest);
 
         //when
-        LocalDateTime startDate = LocalDateTime.now().plusSeconds(2);
+        LocalDateTime startDate = LocalDateTime.now().plusSeconds(1);
         LocalDateTime endDate = LocalDateTime.now().plusSeconds(10);
         int goalQuantity = 5;
 
@@ -145,11 +145,38 @@ public class CampaignServiceTest {
         Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
 
         // then
-        Thread.sleep(5000);
+        Thread.sleep(2000);
 
         Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
                 .orElseThrow();
 
         assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.IN_PROGRESS);
+    }
+
+    @Test
+    void 캠페인_실패_상태_변경_성공() throws InterruptedException {
+        //given
+        String name = "보약";
+        String description = "먹으면 기분이 좋아져요.";
+        int price = 10000;
+        CreateProductRequest productRequest = new CreateProductRequest(name, description, price);
+        Long productId = productService.createProduct(productRequest);
+
+        //when
+        LocalDateTime startDate = LocalDateTime.now();
+        LocalDateTime endDate = LocalDateTime.now().plusSeconds(1);
+        int goalQuantity = 5;
+
+        Long campaignId = campaignService.createCampaign(
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
+        Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
+
+        // then
+        Thread.sleep(2000);
+
+        Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
+                .orElseThrow();
+
+        assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.FAILED);
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -3,9 +3,8 @@ package cholog.wiseshop.domain.campaign;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-import cholog.wiseshop.api.campaign.dto.response.ReadCampaignResponse;
-
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
+import cholog.wiseshop.api.campaign.dto.response.ReadCampaignResponse;
 import cholog.wiseshop.api.campaign.service.CampaignService;
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.api.product.service.ProductService;
@@ -14,6 +13,8 @@ import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.campaign.CampaignState;
 import cholog.wiseshop.db.product.ProductRepository;
 import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -125,7 +126,7 @@ public class CampaignServiceTest {
         assertThatThrownBy(() -> campaignService.readCampaign(wrongId))
                 .isInstanceOf(IllegalArgumentException.class);
     }
-    
+
     @Test
     void 캠페인_시작_상태_변경_성공() throws InterruptedException {
         //given
@@ -145,12 +146,13 @@ public class CampaignServiceTest {
         Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
 
         // then
-        Thread.sleep(2000);
-
-        Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
-                .orElseThrow();
-
-        assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.IN_PROGRESS);
+        Awaitility.await()
+                .atLeast(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
+                            .orElseThrow();
+                    assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.IN_PROGRESS);
+                });
     }
 
     @Test
@@ -172,11 +174,12 @@ public class CampaignServiceTest {
         Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
 
         // then
-        Thread.sleep(2000);
-
-        Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
-                .orElseThrow();
-
-        assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.FAILED);
+        Awaitility.await()
+                .atLeast(1,TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
+                            .orElseThrow();
+                    assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.FAILED);
+                });
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -1,10 +1,11 @@
 package cholog.wiseshop.domain.campaign;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import cholog.wiseshop.api.campaign.dto.response.ReadCampaignResponse;
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
-import cholog.wiseshop.api.campaign.dto.response.ReadCampaignResponse;
 import cholog.wiseshop.api.campaign.service.CampaignService;
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.api.product.service.ProductService;
@@ -49,8 +50,8 @@ public class CampaignServiceTest {
         Long productId = productService.createProduct(productRequest);
 
         //when
-        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
-        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30, 10);
+        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30, 10);
         int goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
@@ -123,5 +124,32 @@ public class CampaignServiceTest {
         //then
         assertThatThrownBy(() -> campaignService.readCampaign(wrongId))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+    
+    @Test
+    void 캠페인_시작_상태_변경_성공() throws InterruptedException {
+        //given
+        String name = "보약";
+        String description = "먹으면 기분이 좋아져요.";
+        int price = 10000;
+        CreateProductRequest productRequest = new CreateProductRequest(name, description, price);
+        Long productId = productService.createProduct(productRequest);
+
+        //when
+        LocalDateTime startDate = LocalDateTime.now().plusSeconds(2);
+        LocalDateTime endDate = LocalDateTime.now().plusSeconds(10);
+        int goalQuantity = 5;
+
+        Long campaignId = campaignService.createCampaign(
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
+        Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
+
+        // then
+        Thread.sleep(5000);
+
+        Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
+                .orElseThrow();
+
+        assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.IN_PROGRESS);
     }
 }


### PR DESCRIPTION
`TaskScheduler`의 구현체인 `ThreadPoolTaskScheduler`를 사용해보았습니다.
3초 후에 시작하는 캠페인을 통해 테스트를 진행해보았습니다.

### 고난
- `Awaitility`의 `atLeast()` 메서드 사용 시에는 테스트가 실패합니다. update쿼리는 날아가는데, 반영이 안되었습니다.

### 해결
- `Thread.sleep`을 하니까 되었습니다... 왜인지를 아직 잘 모르겠어요.. 하지만 우선 올려봅니다

---
리팩터링이 필요한 코드입니다!
테스트 시간이 해당 기능 테스트만해도 초 단위이므로, 이 시간을 줄여야 할 것 같아요