### PR TITLE
feat: 상품 생성/삭제 시, 재고도 생성/삭제되는 기능 구현 및 테스트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,12 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+### Mac ###
+.DS_Store
+._.DS_Store
+**/.DS_Store
+**/._.DS_Store
+
 ### STS ###
 .apt_generated
 .classpath

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -12,7 +12,6 @@ import java.time.ZoneId;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @Transactional
@@ -60,5 +59,11 @@ public class CampaignService {
                 .orElseThrow(() -> new IllegalArgumentException("상태 변경할 캠페인 정보가 존재하지 않습니다."));
         campaign.updateState(state);
         campaignRepository.saveAndFlush(campaign);
+    }
+
+    public boolean isStarted(Long campaignId, LocalDateTime now) {
+        Campaign campaign = campaignRepository.findById(campaignId)
+                .orElseThrow(() -> new IllegalArgumentException("캠페인이 존재하지 않습니다."));
+        return campaign.getStartDate().isBefore(now);
     }
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -61,9 +61,12 @@ public class CampaignService {
         campaignRepository.saveAndFlush(campaign);
     }
 
-    public boolean isStarted(Long campaignId, LocalDateTime now) {
+    public boolean isStarted(Long campaignId) {
         Campaign campaign = campaignRepository.findById(campaignId)
                 .orElseThrow(() -> new IllegalArgumentException("캠페인이 존재하지 않습니다."));
-        return campaign.getStartDate().isBefore(now);
+        if (campaign.getState().equals(CampaignState.IN_PROGRESS)) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/cholog/wiseshop/api/order/controller/OrderController.java
+++ b/src/main/java/cholog/wiseshop/api/order/controller/OrderController.java
@@ -1,13 +1,16 @@
 package cholog.wiseshop.api.order.controller;
 
 import cholog.wiseshop.api.order.dto.CreateOrderRequest;
+import cholog.wiseshop.api.order.dto.ModifyOrderCountRequest;
 import cholog.wiseshop.api.order.dto.OrderResponse;
 import cholog.wiseshop.api.order.service.OrderService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1")
 public class OrderController {
 
-    private OrderService orderService;
+    private final OrderService orderService;
 
     public OrderController(OrderService orderService) {
         this.orderService = orderService;
@@ -32,5 +35,17 @@ public class OrderController {
     public ResponseEntity<OrderResponse> readOrder(@PathVariable Long id) {
         OrderResponse response = orderService.readOrder(id);
         return ResponseEntity.ok(response);
+    }
+
+    @PutMapping
+    public ResponseEntity<Void> modifyOrderCount(@RequestBody ModifyOrderCountRequest request) {
+        orderService.modifyOrderCount(request);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteOrder(@PathVariable Long id) {
+        orderService.deleteOrder(id);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/cholog/wiseshop/api/order/controller/OrderController.java
+++ b/src/main/java/cholog/wiseshop/api/order/controller/OrderController.java
@@ -1,0 +1,36 @@
+package cholog.wiseshop.api.order.controller;
+
+import cholog.wiseshop.api.order.dto.CreateOrderRequest;
+import cholog.wiseshop.api.order.dto.OrderResponse;
+import cholog.wiseshop.api.order.service.OrderService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class OrderController {
+
+    private OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Long> createOrder(@RequestBody CreateOrderRequest request) {
+        Long orderId = orderService.createOrder(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(orderId);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<OrderResponse> readOrder(@PathVariable Long id) {
+        OrderResponse response = orderService.readOrder(id);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/cholog/wiseshop/api/order/controller/OrderController.java
+++ b/src/main/java/cholog/wiseshop/api/order/controller/OrderController.java
@@ -1,16 +1,16 @@
 package cholog.wiseshop.api.order.controller;
 
-import cholog.wiseshop.api.order.dto.CreateOrderRequest;
-import cholog.wiseshop.api.order.dto.ModifyOrderCountRequest;
-import cholog.wiseshop.api.order.dto.OrderResponse;
+import cholog.wiseshop.api.order.dto.request.CreateOrderRequest;
+import cholog.wiseshop.api.order.dto.request.ModifyOrderCountRequest;
+import cholog.wiseshop.api.order.dto.response.OrderResponse;
 import cholog.wiseshop.api.order.service.OrderService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -37,9 +37,9 @@ public class OrderController {
         return ResponseEntity.ok(response);
     }
 
-    @PutMapping
-    public ResponseEntity<Void> modifyOrderCount(@RequestBody ModifyOrderCountRequest request) {
-        orderService.modifyOrderCount(request);
+    @PatchMapping("/{id}")
+    public ResponseEntity<Void> modifyOrderCount(@PathVariable Long id, @RequestBody ModifyOrderCountRequest request) {
+        orderService.modifyOrderCount(id, request);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 

--- a/src/main/java/cholog/wiseshop/api/order/controller/OrderController.java
+++ b/src/main/java/cholog/wiseshop/api/order/controller/OrderController.java
@@ -40,7 +40,7 @@ public class OrderController {
     @PatchMapping("/{id}")
     public ResponseEntity<Void> modifyOrderCount(@PathVariable Long id, @RequestBody ModifyOrderCountRequest request) {
         orderService.modifyOrderCount(id, request);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/cholog/wiseshop/api/order/dto/CreateOrderRequest.java
+++ b/src/main/java/cholog/wiseshop/api/order/dto/CreateOrderRequest.java
@@ -1,0 +1,5 @@
+package cholog.wiseshop.api.order.dto;
+
+public record CreateOrderRequest(Long productId,
+                                 int count) {
+}

--- a/src/main/java/cholog/wiseshop/api/order/dto/CreateOrderRequest.java
+++ b/src/main/java/cholog/wiseshop/api/order/dto/CreateOrderRequest.java
@@ -1,5 +1,13 @@
 package cholog.wiseshop.api.order.dto;
 
-public record CreateOrderRequest(Long productId,
-                                 int count) {
+import cholog.wiseshop.db.order.Order;
+import cholog.wiseshop.db.product.Product;
+
+public record CreateOrderRequest(Long productId, int count) {
+    public Order from(Product product) {
+        return new Order(
+                product,
+                this.count
+        );
+    }
 }

--- a/src/main/java/cholog/wiseshop/api/order/dto/ModifyOrderCountRequest.java
+++ b/src/main/java/cholog/wiseshop/api/order/dto/ModifyOrderCountRequest.java
@@ -1,5 +1,0 @@
-package cholog.wiseshop.api.order.dto;
-
-public record ModifyOrderCountRequest(Long id,
-                                      int count) {
-}

--- a/src/main/java/cholog/wiseshop/api/order/dto/ModifyOrderCountRequest.java
+++ b/src/main/java/cholog/wiseshop/api/order/dto/ModifyOrderCountRequest.java
@@ -1,0 +1,5 @@
+package cholog.wiseshop.api.order.dto;
+
+public record ModifyOrderCountRequest(Long id,
+                                      int count) {
+}

--- a/src/main/java/cholog/wiseshop/api/order/dto/OrderResponse.java
+++ b/src/main/java/cholog/wiseshop/api/order/dto/OrderResponse.java
@@ -1,0 +1,20 @@
+package cholog.wiseshop.api.order.dto;
+
+import cholog.wiseshop.db.order.Order;
+import java.time.LocalDateTime;
+
+public record OrderResponse(Long id,
+                            Long productId,
+                            int count,
+                            LocalDateTime createdDate,
+                            LocalDateTime modifiedDate) {
+    public OrderResponse(Order order) {
+        this(
+                order.getId(),
+                order.getProduct().getId(),
+                order.getCount(),
+                order.getCreatedDate(),
+                order.getModifiedDate()
+        );
+    }
+}

--- a/src/main/java/cholog/wiseshop/api/order/dto/OrderResponse.java
+++ b/src/main/java/cholog/wiseshop/api/order/dto/OrderResponse.java
@@ -8,6 +8,7 @@ public record OrderResponse(Long id,
                             int count,
                             LocalDateTime createdDate,
                             LocalDateTime modifiedDate) {
+
     public OrderResponse(Order order) {
         this(
                 order.getId(),

--- a/src/main/java/cholog/wiseshop/api/order/dto/request/CreateOrderRequest.java
+++ b/src/main/java/cholog/wiseshop/api/order/dto/request/CreateOrderRequest.java
@@ -1,4 +1,4 @@
-package cholog.wiseshop.api.order.dto;
+package cholog.wiseshop.api.order.dto.request;
 
 import cholog.wiseshop.db.order.Order;
 import cholog.wiseshop.db.product.Product;

--- a/src/main/java/cholog/wiseshop/api/order/dto/request/ModifyOrderCountRequest.java
+++ b/src/main/java/cholog/wiseshop/api/order/dto/request/ModifyOrderCountRequest.java
@@ -1,0 +1,4 @@
+package cholog.wiseshop.api.order.dto.request;
+
+public record ModifyOrderCountRequest(int count) {
+}

--- a/src/main/java/cholog/wiseshop/api/order/dto/response/OrderResponse.java
+++ b/src/main/java/cholog/wiseshop/api/order/dto/response/OrderResponse.java
@@ -1,4 +1,4 @@
-package cholog.wiseshop.api.order.dto;
+package cholog.wiseshop.api.order.dto.response;
 
 import cholog.wiseshop.db.order.Order;
 import java.time.LocalDateTime;

--- a/src/main/java/cholog/wiseshop/api/order/dto/response/OrderResponse.java
+++ b/src/main/java/cholog/wiseshop/api/order/dto/response/OrderResponse.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 
 public record OrderResponse(Long id,
                             Long productId,
+                            String productName,
                             int count,
                             LocalDateTime createdDate,
                             LocalDateTime modifiedDate) {
@@ -13,6 +14,7 @@ public record OrderResponse(Long id,
         this(
                 order.getId(),
                 order.getProduct().getId(),
+                order.getProduct().getName(),
                 order.getCount(),
                 order.getCreatedDate(),
                 order.getModifiedDate()

--- a/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
+++ b/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
@@ -1,0 +1,20 @@
+package cholog.wiseshop.api.order.service;
+
+import cholog.wiseshop.db.order.OrderRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+
+    public OrderService(OrderRepository orderRepository) {
+        this.orderRepository = orderRepository;
+    }
+
+    public Long createOrder() {
+
+    }
+}

--- a/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
+++ b/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
@@ -1,8 +1,8 @@
 package cholog.wiseshop.api.order.service;
 
-import cholog.wiseshop.api.order.dto.CreateOrderRequest;
-import cholog.wiseshop.api.order.dto.ModifyOrderCountRequest;
-import cholog.wiseshop.api.order.dto.OrderResponse;
+import cholog.wiseshop.api.order.dto.request.CreateOrderRequest;
+import cholog.wiseshop.api.order.dto.request.ModifyOrderCountRequest;
+import cholog.wiseshop.api.order.dto.response.OrderResponse;
 import cholog.wiseshop.db.order.Order;
 import cholog.wiseshop.db.order.OrderRepository;
 import cholog.wiseshop.db.product.Product;
@@ -36,8 +36,8 @@ public class OrderService {
         return new OrderResponse(order);
     }
 
-    public void modifyOrderCount(ModifyOrderCountRequest request) {
-        Order order = orderRepository.findById(request.id())
+    public void modifyOrderCount(Long orderId, ModifyOrderCountRequest request) {
+        Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new IllegalArgumentException("수정할 상품이 존재하지 않습니다."));
         order.updateCount(request.count());
     }

--- a/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
+++ b/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
@@ -1,6 +1,7 @@
 package cholog.wiseshop.api.order.service;
 
 import cholog.wiseshop.api.order.dto.CreateOrderRequest;
+import cholog.wiseshop.api.order.dto.ModifyOrderCountRequest;
 import cholog.wiseshop.api.order.dto.OrderResponse;
 import cholog.wiseshop.db.order.Order;
 import cholog.wiseshop.db.order.OrderRepository;
@@ -28,9 +29,22 @@ public class OrderService {
         return order.getId();
     }
 
+    @Transactional(readOnly = true)
     public OrderResponse readOrder(Long id) {
         Order order = orderRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("주문 정보가 존재하지 않습니다."));
         return new OrderResponse(order);
+    }
+
+    public void modifyOrderCount(ModifyOrderCountRequest request) {
+        Order order = orderRepository.findById(request.id())
+                .orElseThrow(() -> new IllegalArgumentException("수정할 상품이 존재하지 않습니다."));
+        order.updateCount(request.count());
+    }
+
+    public void deleteOrder(Long id) {
+        orderRepository.findById(id)
+                        .orElseThrow(() -> new IllegalArgumentException("삭제할 주문이 존재하지 않습니다."));
+        orderRepository.deleteById(id);
     }
 }

--- a/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
+++ b/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
@@ -1,6 +1,11 @@
 package cholog.wiseshop.api.order.service;
 
+import cholog.wiseshop.api.order.dto.CreateOrderRequest;
+import cholog.wiseshop.api.order.dto.OrderResponse;
+import cholog.wiseshop.db.order.Order;
 import cholog.wiseshop.db.order.OrderRepository;
+import cholog.wiseshop.db.product.Product;
+import cholog.wiseshop.db.product.ProductRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,12 +14,23 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderService {
 
     private final OrderRepository orderRepository;
+    private final ProductRepository productRepository;
 
-    public OrderService(OrderRepository orderRepository) {
+    public OrderService(OrderRepository orderRepository, ProductRepository productRepository) {
         this.orderRepository = orderRepository;
+        this.productRepository = productRepository;
     }
 
-    public Long createOrder() {
+    public Long createOrder(CreateOrderRequest request) {
+        Product orderProduct = productRepository.findById(request.productId())
+                .orElseThrow(() -> new IllegalArgumentException("주문할 상품이 존재하지 않습니다."));
+        Order order = orderRepository.save(request.from(orderProduct));
+        return order.getId();
+    }
 
+    public OrderResponse readOrder(Long id) {
+        Order order = orderRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("주문 정보가 존재하지 않습니다."));
+        return new OrderResponse(order);
     }
 }

--- a/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
+++ b/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
@@ -9,9 +9,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -37,16 +37,18 @@ public class ProductController {
         return ResponseEntity.status(HttpStatus.OK).body(productService.getProduct(id));
     }
 
-    @PutMapping("/products")
-    public ResponseEntity<Void> modifyProduct(@RequestBody ModifyProductRequest request) {
-        productService.modifyProduct(request);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    @PatchMapping("/products/{id}")
+    public ResponseEntity<Void> modifyProduct(@PathVariable Long id,
+                                              @RequestBody ModifyProductRequest request) {
+        productService.modifyProduct(id, request);
+        return ResponseEntity.ok().build();
     }
 
-    @PutMapping("/products/price")
-    public ResponseEntity<Void> modifyProductPrice(@RequestBody ModifyProductPriceRequest request) {
-        productService.modifyProductPrice(request);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    @PatchMapping("/products/{id}/price")
+    public ResponseEntity<Void> modifyProductPrice(@PathVariable Long id,
+                                                   @RequestBody ModifyProductPriceRequest request) {
+        productService.modifyProductPrice(id, request);
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/products/{id}")

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/CreateProductRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/CreateProductRequest.java
@@ -4,7 +4,8 @@ import cholog.wiseshop.db.product.Product;
 
 public record CreateProductRequest(String name,
                                    String description,
-                                   int price) {
+                                   Integer price,
+                                   Integer totalQuantity) {
 
     public Product from() {
         return new Product(

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductPriceRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductPriceRequest.java
@@ -1,5 +1,4 @@
 package cholog.wiseshop.api.product.dto.request;
 
-public record ModifyProductPriceRequest(Long productId,
-                                        int price) {
+public record ModifyProductPriceRequest(int price) {
 }

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductRequest.java
@@ -1,6 +1,5 @@
 package cholog.wiseshop.api.product.dto.request;
 
-public record ModifyProductRequest(Long productId,
-                                   String name,
+public record ModifyProductRequest(String name,
                                    String description) {
 }

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyQuantityRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyQuantityRequest.java
@@ -1,0 +1,5 @@
+package cholog.wiseshop.api.product.dto.request;
+
+public record ModifyQuantityRequest(Long productId,
+                                    Integer modifyQuantity) {
+}

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyQuantityRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyQuantityRequest.java
@@ -1,5 +1,6 @@
 package cholog.wiseshop.api.product.dto.request;
 
-public record ModifyQuantityRequest(Long productId,
+public record ModifyQuantityRequest(Long campaignId,
+                                    Long productId,
                                     Integer modifyQuantity) {
 }

--- a/src/main/java/cholog/wiseshop/api/product/dto/response/ProductResponse.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/response/ProductResponse.java
@@ -4,13 +4,15 @@ import cholog.wiseshop.db.product.Product;
 
 public record ProductResponse(String name,
                               String description,
-                              int price) {
+                              Integer price,
+                              Integer totalQuantity) {
 
     public ProductResponse(Product product) {
         this(
                 product.getName(),
                 product.getDescription(),
-                product.getPrice()
+                product.getPrice(),
+                product.getStock().getTotalQuantity()
         );
     }
 }

--- a/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
+++ b/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
@@ -3,6 +3,7 @@ package cholog.wiseshop.api.product.service;
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductPriceRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
+import cholog.wiseshop.api.product.dto.request.ModifyQuantityRequest;
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
@@ -16,7 +17,7 @@ public class ProductService {
 
     private final ProductRepository productRepository;
 
-    public ProductService (ProductRepository productRepository) {
+    public ProductService(ProductRepository productRepository) {
         this.productRepository = productRepository;
     }
 
@@ -34,7 +35,7 @@ public class ProductService {
     }
 
     public void modifyProduct(ModifyProductRequest request) {
-        Product existedProduct= productRepository.findById(request.productId())
+        Product existedProduct = productRepository.findById(request.productId())
                 .orElseThrow(() -> new IllegalArgumentException("이름 및 설명글 수정할 상품이 존재하지 않습니다."));
         existedProduct.modifyProduct(request.name(), request.description());
         productRepository.save(existedProduct);
@@ -45,6 +46,13 @@ public class ProductService {
                 .orElseThrow(() -> new IllegalArgumentException("가격 수정할 상품이 존재하지 않습니다."));
         existedProduct.modifyPrice(request.price());
         productRepository.save(existedProduct);
+    }
+
+    public void modifyStockQuantity(ModifyQuantityRequest request) {
+        Product existedProduct = productRepository.findById(request.productId())
+                .orElseThrow(() -> new IllegalArgumentException("상품 조회에 실패했습니다."));
+        Stock existedStock = existedProduct.getStock();
+        existedStock.modifyTotalQuantity(request.modifyQuantity());
     }
 
     public void deleteProduct(Long id) {

--- a/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
+++ b/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
@@ -6,6 +6,7 @@ import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
+import cholog.wiseshop.db.stock.Stock;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,7 +21,9 @@ public class ProductService {
     }
 
     public Long createProduct(CreateProductRequest request) {
-        Product createdProduct = productRepository.save(request.from());
+        Stock stock = new Stock(request.totalQuantity());
+        Product product = new Product(request.name(), request.description(), request.price(), stock);
+        Product createdProduct = productRepository.save(product);
         return createdProduct.getId();
     }
 

--- a/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
+++ b/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
@@ -38,15 +38,15 @@ public class ProductService {
                 .orElseThrow(() -> new IllegalArgumentException("상품 조회에 실패했습니다.")));
     }
 
-    public void modifyProduct(ModifyProductRequest request) {
-        Product existedProduct = productRepository.findById(request.productId())
+    public void modifyProduct(Long productId, ModifyProductRequest request) {
+        Product existedProduct = productRepository.findById(productId)
                 .orElseThrow(() -> new IllegalArgumentException("이름 및 설명글 수정할 상품이 존재하지 않습니다."));
         existedProduct.modifyProduct(request.name(), request.description());
         productRepository.save(existedProduct);
     }
 
-    public void modifyProductPrice(ModifyProductPriceRequest request) {
-        Product existedProduct = productRepository.findById(request.productId())
+    public void modifyProductPrice(Long productId, ModifyProductPriceRequest request) {
+        Product existedProduct = productRepository.findById(productId)
                 .orElseThrow(() -> new IllegalArgumentException("가격 수정할 상품이 존재하지 않습니다."));
         existedProduct.modifyPrice(request.price());
         productRepository.save(existedProduct);

--- a/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
+++ b/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
@@ -1,5 +1,6 @@
 package cholog.wiseshop.api.product.service;
 
+import cholog.wiseshop.api.campaign.service.CampaignService;
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductPriceRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
@@ -8,6 +9,7 @@ import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
 import cholog.wiseshop.db.stock.Stock;
+import java.time.LocalDateTime;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,9 +18,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProductService {
 
     private final ProductRepository productRepository;
+    private final CampaignService campaignService;
 
-    public ProductService(ProductRepository productRepository) {
+    public ProductService(ProductRepository productRepository, CampaignService campaignService) {
         this.productRepository = productRepository;
+        this.campaignService = campaignService;
     }
 
     public Long createProduct(CreateProductRequest request) {
@@ -49,6 +53,9 @@ public class ProductService {
     }
 
     public void modifyStockQuantity(ModifyQuantityRequest request) {
+        if (campaignService.isStarted(request.campaignId(), LocalDateTime.now())) {
+            throw new IllegalArgumentException("캠페인이 시작되어 상품을 수정할 수 없습니다.");
+        }
         Product existedProduct = productRepository.findById(request.productId())
                 .orElseThrow(() -> new IllegalArgumentException("상품 조회에 실패했습니다."));
         Stock existedStock = existedProduct.getStock();

--- a/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
+++ b/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
@@ -53,7 +53,7 @@ public class ProductService {
     }
 
     public void modifyStockQuantity(ModifyQuantityRequest request) {
-        if (campaignService.isStarted(request.campaignId(), LocalDateTime.now())) {
+        if (campaignService.isStarted(request.campaignId())) {
             throw new IllegalArgumentException("캠페인이 시작되어 상품을 수정할 수 없습니다.");
         }
         Product existedProduct = productRepository.findById(request.productId())

--- a/src/main/java/cholog/wiseshop/db/BaseTimeEntity.java
+++ b/src/main/java/cholog/wiseshop/db/BaseTimeEntity.java
@@ -1,0 +1,27 @@
+package cholog.wiseshop.db;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+
+    public LocalDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public LocalDateTime getModifiedDate() {
+        return modifiedDate;
+    }
+}

--- a/src/main/java/cholog/wiseshop/db/order/Order.java
+++ b/src/main/java/cholog/wiseshop/db/order/Order.java
@@ -1,0 +1,60 @@
+package cholog.wiseshop.db.order;
+
+import cholog.wiseshop.db.product.Product;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
+
+@Entity
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "PRODUCT_ID")
+    private Product product;
+
+    private int count;
+
+    private LocalDateTime createdDate;
+
+    private LocalDateTime modifiedDate;
+
+    public Order(Product product, int count, LocalDateTime createdDate, LocalDateTime modifiedDate) {
+        this.product = product;
+        this.count = count;
+        this.createdDate = createdDate;
+        this.modifiedDate = modifiedDate;
+    }
+
+    public Order() {
+
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public LocalDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public LocalDateTime getModifiedDate() {
+        return modifiedDate;
+    }
+}

--- a/src/main/java/cholog/wiseshop/db/order/Order.java
+++ b/src/main/java/cholog/wiseshop/db/order/Order.java
@@ -9,8 +9,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 
 @Entity
+@Table(name = "`order`")
 public class Order extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/cholog/wiseshop/db/order/Order.java
+++ b/src/main/java/cholog/wiseshop/db/order/Order.java
@@ -23,9 +23,7 @@ public class Order extends BaseTimeEntity {
 
     private int count;
 
-    public Order() {
-
-    }
+    public Order() {}
 
     public Order(Product product, int count) {
         this.product = product;

--- a/src/main/java/cholog/wiseshop/db/order/Order.java
+++ b/src/main/java/cholog/wiseshop/db/order/Order.java
@@ -32,6 +32,10 @@ public class Order extends BaseTimeEntity {
         this.count = count;
     }
 
+    public void updateCount(int count) {
+        this.count = count;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/cholog/wiseshop/db/order/Order.java
+++ b/src/main/java/cholog/wiseshop/db/order/Order.java
@@ -1,5 +1,6 @@
 package cholog.wiseshop.db.order;
 
+import cholog.wiseshop.db.BaseTimeEntity;
 import cholog.wiseshop.db.product.Product;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -8,10 +9,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
-import java.time.LocalDateTime;
 
 @Entity
-public class Order {
+public class Order extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,19 +23,13 @@ public class Order {
 
     private int count;
 
-    private LocalDateTime createdDate;
-
-    private LocalDateTime modifiedDate;
-
-    public Order(Product product, int count, LocalDateTime createdDate, LocalDateTime modifiedDate) {
-        this.product = product;
-        this.count = count;
-        this.createdDate = createdDate;
-        this.modifiedDate = modifiedDate;
-    }
-
     public Order() {
 
+    }
+
+    public Order(Product product, int count) {
+        this.product = product;
+        this.count = count;
     }
 
     public Long getId() {
@@ -48,13 +42,5 @@ public class Order {
 
     public int getCount() {
         return count;
-    }
-
-    public LocalDateTime getCreatedDate() {
-        return createdDate;
-    }
-
-    public LocalDateTime getModifiedDate() {
-        return modifiedDate;
     }
 }

--- a/src/main/java/cholog/wiseshop/db/order/OrderRepository.java
+++ b/src/main/java/cholog/wiseshop/db/order/OrderRepository.java
@@ -1,0 +1,6 @@
+package cholog.wiseshop.db.order;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/cholog/wiseshop/db/product/Product.java
+++ b/src/main/java/cholog/wiseshop/db/product/Product.java
@@ -1,9 +1,14 @@
 package cholog.wiseshop.db.product;
 
+import cholog.wiseshop.db.stock.Stock;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
 
 @Entity
 public class Product {
@@ -17,6 +22,18 @@ public class Product {
     private String description;
 
     private int price;
+
+    @OneToOne
+    @JoinColumn(name = "STOCK_ID")
+    @Cascade(value = CascadeType.ALL)
+    private Stock stock;
+
+    public Product(String name, String description, Integer price, Stock stock) {
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.stock = stock;
+    }
 
     public Product(String name, String description, int price) {
         this.name = name;
@@ -51,5 +68,9 @@ public class Product {
 
     public int getPrice() {
         return price;
+    }
+
+    public Stock getStock() {
+        return stock;
     }
 }

--- a/src/main/java/cholog/wiseshop/db/product/Product.java
+++ b/src/main/java/cholog/wiseshop/db/product/Product.java
@@ -1,14 +1,15 @@
 package cholog.wiseshop.db.product;
 
 import cholog.wiseshop.db.stock.Stock;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
 
 @Entity
 public class Product {
@@ -23,9 +24,8 @@ public class Product {
 
     private int price;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     @JoinColumn(name = "STOCK_ID")
-    @Cascade(value = CascadeType.ALL)
     private Stock stock;
 
     public Product(String name, String description, Integer price, Stock stock) {

--- a/src/main/java/cholog/wiseshop/db/stock/Stock.java
+++ b/src/main/java/cholog/wiseshop/db/stock/Stock.java
@@ -8,6 +8,8 @@ import jakarta.persistence.Id;
 @Entity
 public class Stock {
 
+    private static final Integer MINIMUM_QUANTITY = 1;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -27,5 +29,12 @@ public class Stock {
 
     public Integer getTotalQuantity() {
         return totalQuantity;
+    }
+
+    public void modifyTotalQuantity(Integer modifyQuantity) {
+        if (modifyQuantity < MINIMUM_QUANTITY) {
+            throw new IllegalArgumentException("재고 수량은 최소 1개 이상이어야 합니다.");
+        }
+        this.totalQuantity = modifyQuantity;
     }
 }

--- a/src/main/java/cholog/wiseshop/db/stock/Stock.java
+++ b/src/main/java/cholog/wiseshop/db/stock/Stock.java
@@ -1,0 +1,31 @@
+package cholog.wiseshop.db.stock;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Stock {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Integer totalQuantity;
+
+    public Stock(Integer totalQuantity) {
+        this.totalQuantity = totalQuantity;
+    }
+
+    public Stock() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Integer getTotalQuantity() {
+        return totalQuantity;
+    }
+}

--- a/src/main/java/cholog/wiseshop/db/stock/StockRepository.java
+++ b/src/main/java/cholog/wiseshop/db/stock/StockRepository.java
@@ -1,0 +1,6 @@
+package cholog.wiseshop.db.stock;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StockRepository extends JpaRepository<Stock, Long> {
+}

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -1,5 +1,6 @@
 package cholog.wiseshop.domain.campaign;
 
+import static cholog.wiseshop.domain.product.ProductRepositoryTest.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
@@ -12,6 +13,7 @@ import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.campaign.CampaignState;
 import cholog.wiseshop.db.product.ProductRepository;
+import cholog.wiseshop.domain.product.ProductRepositoryTest;
 import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
@@ -44,11 +46,9 @@ public class CampaignServiceTest {
     @Test
     void 캠페인_추가하기() {
         //given
-        String name = "보약";
-        String description = "먹으면 기분이 좋아져요.";
-        int price = 10000;
-        CreateProductRequest productRequest = new CreateProductRequest(name, description, price);
-        Long productId = productService.createProduct(productRequest);
+        CreateProductRequest request = getCreateProductRequest();
+
+        Long productId = productService.createProduct(request);
 
         //when
         LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30, 10);
@@ -84,11 +84,8 @@ public class CampaignServiceTest {
     @Test
     void 캠페인_조회하기() {
         //given
-        String name = "보약";
-        String description = "먹으면 기분이 좋아져요.";
-        int price = 10000;
-        CreateProductRequest productRequest = new CreateProductRequest(name, description, price);
-        Long productId = productService.createProduct(productRequest);
+        CreateProductRequest request = getCreateProductRequest();
+        Long productId = productService.createProduct(request);
 
         //when
         LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
@@ -107,11 +104,8 @@ public class CampaignServiceTest {
     @Test
     void 캠페인_조회하기_예외_잘못된_캠페인ID() {
         //given
-        String name = "보약";
-        String description = "먹으면 기분이 좋아져요.";
-        int price = 10000;
-        CreateProductRequest productRequest = new CreateProductRequest(name, description, price);
-        Long productId = productService.createProduct(productRequest);
+        CreateProductRequest request = getCreateProductRequest();
+        Long productId = productService.createProduct(request);
 
         //when
         LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
@@ -130,11 +124,8 @@ public class CampaignServiceTest {
     @Test
     void 캠페인_시작_상태_변경_성공() throws InterruptedException {
         //given
-        String name = "보약";
-        String description = "먹으면 기분이 좋아져요.";
-        int price = 10000;
-        CreateProductRequest productRequest = new CreateProductRequest(name, description, price);
-        Long productId = productService.createProduct(productRequest);
+        CreateProductRequest request = getCreateProductRequest();
+        Long productId = productService.createProduct(request);
 
         //when
         LocalDateTime startDate = LocalDateTime.now().plusSeconds(1);
@@ -158,11 +149,8 @@ public class CampaignServiceTest {
     @Test
     void 캠페인_실패_상태_변경_성공() throws InterruptedException {
         //given
-        String name = "보약";
-        String description = "먹으면 기분이 좋아져요.";
-        int price = 10000;
-        CreateProductRequest productRequest = new CreateProductRequest(name, description, price);
-        Long productId = productService.createProduct(productRequest);
+        CreateProductRequest request = getCreateProductRequest();
+        Long productId = productService.createProduct(request);
 
         //when
         LocalDateTime startDate = LocalDateTime.now();

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -18,6 +18,7 @@ import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -169,5 +170,26 @@ public class CampaignServiceTest {
                             .orElseThrow();
                     assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.FAILED);
                 });
+    }
+
+    @Test
+    @DisplayName("전달받은 날짜와 캠페인의 시작날짜를 비교해 현재 캠페인이 시작됐는지를 확인합니다.")
+    void 캠페인_시작날짜_비교() {
+        //given
+        CreateProductRequest request = getCreateProductRequest();
+        Long productId = productService.createProduct(request);
+
+        //when
+        LocalDateTime startDate = LocalDateTime.now();
+        LocalDateTime requestDate = startDate.plusSeconds(3);
+        LocalDateTime endDate = startDate.plusSeconds(5);
+        int goalQuantity = 5;
+
+        Long campaignId = campaignService.createCampaign(
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
+        boolean isStarted = campaignService.isStarted(campaignId, requestDate);
+
+        // then
+        assertThat(isStarted).isTrue();
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -1,6 +1,6 @@
 package cholog.wiseshop.domain.campaign;
 
-import static cholog.wiseshop.domain.product.ProductRepositoryTest.*;
+import static cholog.wiseshop.domain.product.ProductRepositoryTest.getCreateProductRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
@@ -13,12 +13,10 @@ import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.campaign.CampaignState;
 import cholog.wiseshop.db.product.ProductRepository;
-import cholog.wiseshop.domain.product.ProductRepositoryTest;
 import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -123,7 +121,7 @@ public class CampaignServiceTest {
     }
 
     @Test
-    void 캠페인_시작_상태_변경_성공() throws InterruptedException {
+    void 캠페인_시작_상태_변경_성공() {
         //given
         CreateProductRequest request = getCreateProductRequest();
         Long productId = productService.createProduct(request);
@@ -148,7 +146,7 @@ public class CampaignServiceTest {
     }
 
     @Test
-    void 캠페인_실패_상태_변경_성공() throws InterruptedException {
+    void 캠페인_실패_상태_변경_성공() {
         //given
         CreateProductRequest request = getCreateProductRequest();
         Long productId = productService.createProduct(request);
@@ -164,7 +162,7 @@ public class CampaignServiceTest {
 
         // then
         Awaitility.await()
-                .atLeast(1,TimeUnit.SECONDS)
+                .atLeast(1, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
                     Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
                             .orElseThrow();
@@ -173,23 +171,21 @@ public class CampaignServiceTest {
     }
 
     @Test
-    @DisplayName("전달받은 날짜와 캠페인의 시작날짜를 비교해 현재 캠페인이 시작됐는지를 확인합니다.")
-    void 캠페인_시작날짜_비교() {
+    void 캠페인이_시작됐는지_확인() {
         //given
         CreateProductRequest request = getCreateProductRequest();
         Long productId = productService.createProduct(request);
 
         //when
-        LocalDateTime startDate = LocalDateTime.now();
-        LocalDateTime requestDate = startDate.plusSeconds(3);
-        LocalDateTime endDate = startDate.plusSeconds(5);
+        LocalDateTime startDate = LocalDateTime.now().plusSeconds(1);
+        LocalDateTime endDate = LocalDateTime.now().plusSeconds(10);
         int goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
                 new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
-        boolean isStarted = campaignService.isStarted(campaignId, requestDate);
-
         // then
-        assertThat(isStarted).isTrue();
+        Awaitility.await()
+                .atLeast(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(campaignService.isStarted(campaignId)).isTrue());
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/product/ProductRepositoryTest.java
+++ b/src/test/java/cholog/wiseshop/domain/product/ProductRepositoryTest.java
@@ -22,7 +22,7 @@ public class ProductRepositoryTest {
     }
 
     @Test
-    public void 상품과_재고_저장_조회하기() {
+    public void 상품_저장_조회하기() {
         // given
         CreateProductRequest request = getCreateProductRequest();
 

--- a/src/test/java/cholog/wiseshop/domain/product/ProductRepositoryTest.java
+++ b/src/test/java/cholog/wiseshop/domain/product/ProductRepositoryTest.java
@@ -22,13 +22,9 @@ public class ProductRepositoryTest {
     }
 
     @Test
-    public void 상품_저장_조회하기() {
+    public void 상품과_재고_저장_조회하기() {
         // given
-        String name = "보약";
-        String description = "먹으면 기분이 좋아져요.";
-        int price = 10000;
-
-        CreateProductRequest request = new CreateProductRequest(name, description, price);
+        CreateProductRequest request = getCreateProductRequest();
 
         // when
         Product savedProduct = productRepository.save(request.from());
@@ -36,9 +32,9 @@ public class ProductRepositoryTest {
         Product product = productRepository.findById(savedProduct.getId()).orElseThrow();
 
         // then
-        assertThat(product.getName()).isEqualTo(name);
-        assertThat(product.getDescription()).isEqualTo(description);
-        assertThat(product.getPrice()).isEqualTo(price);
+        assertThat(product.getName()).isEqualTo(request.name());
+        assertThat(product.getDescription()).isEqualTo(request.description());
+        assertThat(product.getPrice()).isEqualTo(request.price());
     }
 
     @Test
@@ -47,11 +43,7 @@ public class ProductRepositoryTest {
         String modifiedName = "보약2";
         String modifiedDescription = "먹으면 기분이 안좋아져요.";
 
-        String name = "보약";
-        String description = "먹으면 기분이 좋아져요.";
-        int price = 10000;
-
-        CreateProductRequest request = new CreateProductRequest(name, description, price);
+        CreateProductRequest request = getCreateProductRequest();
 
         // when
         Product createdProduct = productRepository.save(request.from());
@@ -70,11 +62,7 @@ public class ProductRepositoryTest {
         // given
         int modifiedPrice = 20000;
 
-        String name = "보약";
-        String description = "먹으면 기분이 좋아져요.";
-        int price = 10000;
-
-        CreateProductRequest request = new CreateProductRequest(name, description, price);
+        CreateProductRequest request = getCreateProductRequest();
 
         // when
         Product createdProduct = productRepository.save(request.from());
@@ -90,11 +78,7 @@ public class ProductRepositoryTest {
     @Test
     public void 상품_삭제하기() {
         // given
-        String name = "보약";
-        String description = "먹으면 기분이 좋아져요.";
-        int price = 10000;
-
-        CreateProductRequest request = new CreateProductRequest(name, description, price);
+        final CreateProductRequest request = getCreateProductRequest();
 
         // when
         Product createdProduct = productRepository.save(request.from());
@@ -103,5 +87,14 @@ public class ProductRepositoryTest {
 
         // then
         assertThat(productRepository.findById(createdProduct.getId())).isEmpty();
+    }
+
+    public static CreateProductRequest getCreateProductRequest() {
+        String name = "보약";
+        String description = "먹으면 기분이 좋아져요.";
+        Integer price = 10000;
+        Integer totalQuantity = 5;
+
+        return new CreateProductRequest(name, description, price, totalQuantity);
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/product/ProductRepositoryTest.java
+++ b/src/test/java/cholog/wiseshop/domain/product/ProductRepositoryTest.java
@@ -16,16 +16,16 @@ public class ProductRepositoryTest {
     @Autowired
     private ProductRepository productRepository;
 
+    private static CreateProductRequest request;
+
     @BeforeEach
     public void cleanUp() {
         productRepository.deleteAll();
+        request = getCreateProductRequest();
     }
 
     @Test
     public void 상품_저장_조회하기() {
-        // given
-        CreateProductRequest request = getCreateProductRequest();
-
         // when
         Product savedProduct = productRepository.save(request.from());
 
@@ -42,8 +42,6 @@ public class ProductRepositoryTest {
         // given
         String modifiedName = "보약2";
         String modifiedDescription = "먹으면 기분이 안좋아져요.";
-
-        CreateProductRequest request = getCreateProductRequest();
 
         // when
         Product createdProduct = productRepository.save(request.from());
@@ -62,8 +60,6 @@ public class ProductRepositoryTest {
         // given
         int modifiedPrice = 20000;
 
-        CreateProductRequest request = getCreateProductRequest();
-
         // when
         Product createdProduct = productRepository.save(request.from());
         createdProduct.modifyPrice(modifiedPrice);
@@ -77,9 +73,6 @@ public class ProductRepositoryTest {
 
     @Test
     public void 상품_삭제하기() {
-        // given
-        final CreateProductRequest request = getCreateProductRequest();
-
         // when
         Product createdProduct = productRepository.save(request.from());
 

--- a/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
@@ -2,11 +2,13 @@ package cholog.wiseshop.domain.product;
 
 import static cholog.wiseshop.domain.product.ProductRepositoryTest.getCreateProductRequest;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductPriceRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
+import cholog.wiseshop.api.product.dto.request.ModifyQuantityRequest;
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.api.product.service.ProductService;
 import cholog.wiseshop.db.campaign.CampaignRepository;
@@ -169,6 +171,46 @@ public class ProductServiceTest {
         assertThat(exception.getMessage()).isEqualTo("가격 수정할 상품이 존재하지 않습니다.");
     }
 
+    @Test
+    void 상품_재고_수량_수정_성공() {
+        // given
+        CreateProductRequest request = getCreateProductRequest();
+        Long productId = productService.createProduct(request);
+        Integer modifyQuantity = 1;
+
+        // when
+        ModifyQuantityRequest modifyQuantityRequest = new ModifyQuantityRequest(
+                productId,
+                modifyQuantity
+        );
+        productService.modifyStockQuantity(modifyQuantityRequest);
+
+        Product modifiedProduct = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다."));
+        Stock modifiedStock = modifiedProduct.getStock();
+
+        // then
+        assertThat(modifiedStock.getTotalQuantity()).isEqualTo(modifyQuantity);
+    }
+
+    @Test
+    void 상품_재고_수량_수정_실패() {
+        // given
+        CreateProductRequest request = getCreateProductRequest();
+        Long productId = productService.createProduct(request);
+        Integer modifyQuantity = 0;
+
+        // when
+        ModifyQuantityRequest modifyQuantityRequest = new ModifyQuantityRequest(
+                productId,
+                modifyQuantity
+        );
+
+        // then
+        assertThatThrownBy(() -> productService.modifyStockQuantity(modifyQuantityRequest))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+    
     @Test
     void 상품과_재고_삭제하기() {
         // given

--- a/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
@@ -105,12 +105,11 @@ public class ProductServiceTest {
         Product createdProduct = productRepository.save(request.from());
 
         ModifyProductRequest modifyProductRequest = new ModifyProductRequest(
-                createdProduct.getId(),
                 modifiedName,
                 modifiedDescription
         );
 
-        productService.modifyProduct(modifyProductRequest);
+        productService.modifyProduct(createdProduct.getId(), modifyProductRequest);
 
         Product modifiedProduct = productRepository.findById(createdProduct.getId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다."));
@@ -127,11 +126,11 @@ public class ProductServiceTest {
         String modifiedName = "보약2";
         String modifiedDescription = "먹으면 기분이 안좋아져요.";
 
-        ModifyProductRequest request = new ModifyProductRequest(productId, modifiedName, modifiedDescription);
+        ModifyProductRequest request = new ModifyProductRequest(modifiedName, modifiedDescription);
 
         // when
         Throwable exception = assertThrows(IllegalArgumentException.class,
-                () -> productService.modifyProduct(request));
+                () -> productService.modifyProduct(productId, request));
 
         // then
         assertThat(exception.getMessage()).isEqualTo("이름 및 설명글 수정할 상품이 존재하지 않습니다.");
@@ -147,12 +146,9 @@ public class ProductServiceTest {
         // when
         Product createdProduct = productRepository.save(request.from());
 
-        ModifyProductPriceRequest modifyProductPriceRequest = new ModifyProductPriceRequest(
-                createdProduct.getId(),
-                modifiedPrice
-        );
+        ModifyProductPriceRequest modifyProductPriceRequest = new ModifyProductPriceRequest(modifiedPrice);
 
-        productService.modifyProductPrice(modifyProductPriceRequest);
+        productService.modifyProductPrice(createdProduct.getId(), modifyProductPriceRequest);
 
         Product modifiedProduct = productRepository.findById(createdProduct.getId())
                 .orElseThrow(() -> new IllegalArgumentException("가격 수정할 상품이 존재하지 않습니다."));
@@ -167,11 +163,11 @@ public class ProductServiceTest {
         Long productId = 1L;
         int modifiedPrice = 30000;
 
-        ModifyProductPriceRequest request = new ModifyProductPriceRequest(productId, modifiedPrice);
+        ModifyProductPriceRequest request = new ModifyProductPriceRequest(modifiedPrice);
 
         // when
         Throwable exception = assertThrows(IllegalArgumentException.class,
-                () -> productService.modifyProductPrice(request));
+                () -> productService.modifyProductPrice(productId, request));
 
         // then
         assertThat(exception.getMessage()).isEqualTo("가격 수정할 상품이 존재하지 않습니다.");

--- a/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductPriceRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
+import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.api.product.service.ProductService;
 import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.product.Product;
@@ -34,13 +35,13 @@ public class ProductServiceTest {
     private CampaignRepository campaignRepository;
 
     @BeforeEach
-    public void cleanUp() {
+    void cleanUp() {
         campaignRepository.deleteAll();
-        productRepository.deleteAll();;
+        productRepository.deleteAll();
     }
 
     @Test
-    public void 상품과_재고_저장_성공() {
+    void 상품과_재고_저장_성공() {
         // given
         CreateProductRequest request = getCreateProductRequest();
 
@@ -56,7 +57,23 @@ public class ProductServiceTest {
     }
 
     @Test
-    public void 상품_조회_실패() {
+    void 상품과_재고_조회_성공() {
+        // given
+        CreateProductRequest request = getCreateProductRequest();
+
+        // when
+        Long productId = productService.createProduct(request);
+        ProductResponse response = productService.getProduct(productId);
+
+        // then
+        assertThat(response.name()).isEqualTo(request.name());
+        assertThat(response.price()).isEqualTo(request.price());
+        assertThat(response.description()).isEqualTo(request.description());
+        assertThat(response.totalQuantity()).isEqualTo(request.totalQuantity());
+    }
+
+    @Test
+    void 상품_조회_실패() {
         // given
         Long wrongProductId = 10L;
 
@@ -69,13 +86,12 @@ public class ProductServiceTest {
     }
 
     @Test
-    public void 상품_이름_설명글_수정_성공() {
+    void 상품_이름_설명글_수정_성공() {
         // given
         String modifiedName = "보약2";
         String modifiedDescription = "먹으면 기분이 안좋아져요.";
 
         CreateProductRequest request = getCreateProductRequest();
-
 
         // when
         Product createdProduct = productRepository.save(request.from());
@@ -97,7 +113,7 @@ public class ProductServiceTest {
     }
 
     @Test
-    public void 상품_이름_설명글_수정_실패() {
+    void 상품_이름_설명글_수정_실패() {
         // given
         Long productId = 11L;
         String modifiedName = "보약2";
@@ -114,7 +130,7 @@ public class ProductServiceTest {
     }
 
     @Test
-    public void 상품_가격_수정_성공() {
+    void 상품_가격_수정_성공() {
         // given
         int modifiedPrice = 20000;
 
@@ -138,7 +154,7 @@ public class ProductServiceTest {
     }
 
     @Test
-    public void 상품_가격_수정_실패() {
+    void 상품_가격_수정_실패() {
         // given
         Long productId = 1L;
         int modifiedPrice = 30000;
@@ -154,7 +170,7 @@ public class ProductServiceTest {
     }
 
     @Test
-    public void 상품과_재고_삭제하기() {
+    void 상품과_재고_삭제하기() {
         // given
         CreateProductRequest request = getCreateProductRequest();
         Long productId = productService.createProduct(request);
@@ -170,7 +186,7 @@ public class ProductServiceTest {
     }
 
     @Test
-    public void 상품_삭제_실패() {
+    void 상품_삭제_실패() {
         // given
         Long wrongProductId = 13L;
 

--- a/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
+import cholog.wiseshop.api.campaign.service.CampaignService;
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductPriceRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
@@ -16,6 +18,7 @@ import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
 import cholog.wiseshop.db.stock.Stock;
 import cholog.wiseshop.db.stock.StockRepository;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +35,9 @@ public class ProductServiceTest {
 
     @Autowired
     private StockRepository stockRepository;
+
+    @Autowired
+    private CampaignService campaignService;
 
     @Autowired
     private CampaignRepository campaignRepository;
@@ -176,11 +182,18 @@ public class ProductServiceTest {
         // given
         CreateProductRequest request = getCreateProductRequest();
         Long productId = productService.createProduct(request);
+
+        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30, 10);
+        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30, 10);
+        int goalQuantity = 5;
+
+        Long campaignId = campaignService.createCampaign(
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
         Integer modifyQuantity = 1;
 
         // when
         ModifyQuantityRequest modifyQuantityRequest = new ModifyQuantityRequest(
-                1L,
+                campaignId,
                 productId,
                 modifyQuantity
         );
@@ -199,11 +212,18 @@ public class ProductServiceTest {
         // given
         CreateProductRequest request = getCreateProductRequest();
         Long productId = productService.createProduct(request);
+
+        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30, 10);
+        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30, 10);
+        int goalQuantity = 5;
+
+        Long campaignId = campaignService.createCampaign(
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
         Integer modifyQuantity = 0;
 
         // when
         ModifyQuantityRequest modifyQuantityRequest = new ModifyQuantityRequest(
-                1L,
+                campaignId,
                 productId,
                 modifyQuantity
         );

--- a/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
@@ -180,6 +180,7 @@ public class ProductServiceTest {
 
         // when
         ModifyQuantityRequest modifyQuantityRequest = new ModifyQuantityRequest(
+                1L,
                 productId,
                 modifyQuantity
         );
@@ -202,6 +203,7 @@ public class ProductServiceTest {
 
         // when
         ModifyQuantityRequest modifyQuantityRequest = new ModifyQuantityRequest(
+                1L,
                 productId,
                 modifyQuantity
         );

--- a/src/test/java/cholog/wiseshop/web/product/ProductControllerTest.java
+++ b/src/test/java/cholog/wiseshop/web/product/ProductControllerTest.java
@@ -4,8 +4,8 @@ import static cholog.wiseshop.domain.product.ProductRepositoryTest.getCreateProd
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -134,16 +134,16 @@ public class ProductControllerTest {
         Product savedProduct = productRepository.save(product);
 
         ModifyProductRequest request =
-                new ModifyProductRequest(savedProduct.getId(), modifiedName, modifiedDescription);
+                new ModifyProductRequest(modifiedName, modifiedDescription);
 
-        String url = "http://localhost:" + port + "/api/v1/products";
+        String url = "http://localhost:" + port + "/api/v1/products/";
 
         // then
-        mockMvc.perform(put(url)
+        mockMvc.perform(patch(url + savedProduct.getId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(request))
                         .characterEncoding("utf-8"))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -160,16 +160,16 @@ public class ProductControllerTest {
         // when
         Product savedProduct = productRepository.save(product);
 
-        ModifyProductPriceRequest request = new ModifyProductPriceRequest(savedProduct.getId(), modifiedPrice);
+        ModifyProductPriceRequest request = new ModifyProductPriceRequest(modifiedPrice);
 
-        String url = "http://localhost:" + port + "/api/v1/products/price";
+        String url = "http://localhost:" + port + "/api/v1/products/";
 
         // then
-        mockMvc.perform(put(url)
+        mockMvc.perform(patch(url + savedProduct.getId() + "/price")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(request))
                         .characterEncoding("utf-8"))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isOk());
     }
 
     @Test

--- a/src/test/java/cholog/wiseshop/web/product/ProductControllerTest.java
+++ b/src/test/java/cholog/wiseshop/web/product/ProductControllerTest.java
@@ -1,5 +1,6 @@
-package cholog.wiseshop.web.product.controller;
+package cholog.wiseshop.web.product;
 
+import static cholog.wiseshop.domain.product.ProductRepositoryTest.getCreateProductRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -68,12 +69,7 @@ public class ProductControllerTest {
     @Test
     public void 상품_생성하기() throws Exception {
         // given
-        String name = "보약";
-        String description = "먹으면 기분이 좋아져요.";
-        int price = 10000;
-
-        CreateProductRequest request = new CreateProductRequest(name, description, price);
-
+        CreateProductRequest request = getCreateProductRequest();
         String url = "http://localhost:" + port + "/api/v1/products";
 
         // when
@@ -87,9 +83,9 @@ public class ProductControllerTest {
 
         // then
         Product product = productRepository.findById(1L).orElseThrow();
-        assertThat(product.getName()).isEqualTo(name);
-        assertThat(product.getDescription()).isEqualTo(description);
-        assertThat(product.getPrice()).isEqualTo(price);
+        assertThat(product.getName()).isEqualTo(request.name());
+        assertThat(product.getDescription()).isEqualTo(request.description());
+        assertThat(product.getPrice()).isEqualTo(request.price());
     }
 
     @Test


### PR DESCRIPTION
## 작업내용
- 상품을 생성할 때, 재고도 함께 생성하도록 `ProductService`의 메서드를 변경하였습니다.
- 상품이 삭제될 때, 재고도 함께 삭제되도록 `Product`의 필드인 `Stock`에 `Cascade.ALL` 옵션을 주었습니다.
- 상품을 조회할 때, 재고도 함께 조회하도록 `Product`의 필드니 `Stock`에 `FetchType.EAGER` 옵션을 주었습니다.
- 단위 테스트에서 사용되는 `CreateProductRequest` (상품 추가 DTO)를 생성하는 코드가 `given` 절에서 반복되기에 해당 메서드를 `static`으로 분리하였습니다.

### 재고 수정
- 상품 재고를 수정할 경우, 0개로 수정할 수 없도록 `Stock`에 메서드를 추가하였습니다.
- 상품 재고를 수정할 경우, 이미 캠페인이 진행 중이라면 예외를 발생합니다.

## 리뷰 포인트
- 팀 노션 `DB 설계 -> 2주차 엔티티 설계`에 따르면, `Stock`이 외래 키를 갖도록 설계하였습니다. 다만, 재고를 조회하는 과정이 상품을 먼저 찾고, 그 상품과 연관된 재고를 조회하는 것이 객체 관점에서 더 자연스럽다고 판단했습니다. 따라서 팀 노션 문서의 내용과 다르게 `Product`가 외래 키를 갖도록 구현하였습니다.
- 의문점이 들거나 더 좋은 방법이 있다면 리뷰 부탁드립니다 😄