### PR TITLE
refactor: 캠페인+상품+재고 추가 및 조회 API 수정

### DIFF
--- a/src/main/java/cholog/wiseshop/api/campaign/dto/request/CreateCampaignRequest.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/dto/request/CreateCampaignRequest.java
@@ -1,5 +1,6 @@
 package cholog.wiseshop.api.campaign.dto.request;
 
+import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import java.time.LocalDateTime;
@@ -9,6 +10,6 @@ public record CreateCampaignRequest(
         LocalDateTime startDate,
         @JsonSerialize(using = LocalDateTimeSerializer.class)
         LocalDateTime endDate,
-        int goalQuantity,
-        Long productId) {
+        Integer goalQuantity,
+        CreateProductRequest product) {
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/dto/request/CreateCampaignRequest.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/dto/request/CreateCampaignRequest.java
@@ -10,6 +10,6 @@ public record CreateCampaignRequest(
         LocalDateTime startDate,
         @JsonSerialize(using = LocalDateTimeSerializer.class)
         LocalDateTime endDate,
-        Integer goalQuantity,
+        int goalQuantity,
         CreateProductRequest product) {
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/dto/response/ReadCampaignResponse.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/dto/response/ReadCampaignResponse.java
@@ -1,5 +1,10 @@
 package cholog.wiseshop.api.campaign.dto.response;
 
+import cholog.wiseshop.api.product.dto.response.ProductResponse;
+
 public record ReadCampaignResponse(Long campaignId,
-                                   Long productId) {
+                                    String startDate,
+                                    String endDate,
+                                    Integer goalQuantity,
+                                   ProductResponse product) {
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -33,7 +33,8 @@ public class CampaignService {
     public CampaignService(CampaignRepository campaignRepository,
                            ProductRepository productRepository,
                            StockRepository stockRepository,
-                           ThreadPoolTaskScheduler scheduler, PlatformTransactionManager transactionManager) {
+                           ThreadPoolTaskScheduler scheduler,
+                           PlatformTransactionManager transactionManager) {
         this.campaignRepository = campaignRepository;
         this.productRepository = productRepository;
         this.stockRepository = stockRepository;

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -3,6 +3,7 @@ package cholog.wiseshop.api.campaign.service;
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
 import cholog.wiseshop.api.campaign.dto.response.ReadCampaignResponse;
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
+import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.campaign.CampaignState;
@@ -12,6 +13,7 @@ import cholog.wiseshop.db.stock.Stock;
 import cholog.wiseshop.db.stock.StockRepository;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.List;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,10 +50,15 @@ public class CampaignService {
     }
 
     @Transactional(readOnly = true)
-    public ReadCampaignResponse readCampaign(Long id) {
-        Campaign findCampaign = campaignRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("캠페인이 존재하지 않습니다."));
-        return new ReadCampaignResponse(findCampaign.getId(), findCampaign.getId());
+    public ReadCampaignResponse readCampaign(Long campaignId) {
+        List<Product> findProducts = productRepository.findProductsByCampaignId(campaignId);
+        Product findProduct = findProducts.get(0);
+        Campaign findCampaign = findProduct.getCampaign();
+        return new ReadCampaignResponse(
+                campaignId,
+                findCampaign.getStartDate().toString(),
+                findCampaign.getEndDate().toString(), findCampaign.getGoalQuantity(),
+                new ProductResponse(findProduct));
     }
 
     public void scheduleCampaignDate(Long campaignId, LocalDateTime startDate, LocalDateTime endDate) {

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -52,6 +52,9 @@ public class CampaignService {
     @Transactional(readOnly = true)
     public ReadCampaignResponse readCampaign(Long campaignId) {
         List<Product> findProducts = productRepository.findProductsByCampaignId(campaignId);
+        if (findProducts.isEmpty()) {
+            throw new IllegalArgumentException("캠페인이 존재하지 않습니다.");
+        }
         Product findProduct = findProducts.get(0);
         Campaign findCampaign = findProduct.getCampaign();
         return new ReadCampaignResponse(

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -2,11 +2,14 @@ package cholog.wiseshop.api.campaign.service;
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
 import cholog.wiseshop.api.campaign.dto.response.ReadCampaignResponse;
+import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.campaign.CampaignState;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
+import cholog.wiseshop.db.stock.Stock;
+import cholog.wiseshop.db.stock.StockRepository;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -19,30 +22,36 @@ public class CampaignService {
 
     private final CampaignRepository campaignRepository;
     private final ProductRepository productRepository;
+    private final StockRepository stockRepository;
     private final ThreadPoolTaskScheduler scheduler;
 
     public CampaignService(CampaignRepository campaignRepository,
                            ProductRepository productRepository,
+                           StockRepository stockRepository,
                            ThreadPoolTaskScheduler scheduler) {
         this.campaignRepository = campaignRepository;
         this.productRepository = productRepository;
+        this.stockRepository = stockRepository;
         this.scheduler = scheduler;
     }
 
     public Long createCampaign(CreateCampaignRequest request) {
-        Product findProduct = productRepository.findById(request.productId())
-                .orElseThrow(() -> new IllegalArgumentException("상품이 존재하지 않습니다."));
-        Campaign savedCampaign = campaignRepository.save(
-                new Campaign(findProduct, request.startDate(), request.endDate(), request.goalQuantity()));
-        scheduleCampaignDate(request.productId(), request.startDate(), request.endDate());
-        return savedCampaign.getId();
+        CreateProductRequest productRequest = request.product();
+        Stock stock = stockRepository.save(new Stock(productRequest.totalQuantity()));
+        Product product = productRepository.save(new Product(
+                productRequest.name(), productRequest.description(), productRequest.price(), stock));
+        Campaign campaign = campaignRepository.save(
+                new Campaign(request.startDate(), request.endDate(), request.goalQuantity()));
+        product.addCampaign(campaign);
+        scheduleCampaignDate(campaign.getId(), request.startDate(), request.endDate());
+        return campaign.getId();
     }
 
     @Transactional(readOnly = true)
     public ReadCampaignResponse readCampaign(Long id) {
         Campaign findCampaign = campaignRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("캠페인이 존재하지 않습니다."));
-        return new ReadCampaignResponse(findCampaign.getId(), findCampaign.getProduct().getId());
+        return new ReadCampaignResponse(findCampaign.getId(), findCampaign.getId());
     }
 
     public void scheduleCampaignDate(Long campaignId, LocalDateTime startDate, LocalDateTime endDate) {

--- a/src/main/java/cholog/wiseshop/api/order/dto/request/CreateOrderRequest.java
+++ b/src/main/java/cholog/wiseshop/api/order/dto/request/CreateOrderRequest.java
@@ -3,11 +3,11 @@ package cholog.wiseshop.api.order.dto.request;
 import cholog.wiseshop.db.order.Order;
 import cholog.wiseshop.db.product.Product;
 
-public record CreateOrderRequest(Long productId, int count) {
+public record CreateOrderRequest(Long campaignId, int orderQuantity) {
     public Order from(Product product) {
         return new Order(
                 product,
-                this.count
+                this.orderQuantity
         );
     }
 }

--- a/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
+++ b/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
@@ -32,7 +32,7 @@ public class OrderService {
         }
         Product product = findProducts.get(0);
         Stock stock = product.getStock();
-        if (stock.hasQuantity(request.orderQuantity())) {
+        if (!stock.hasQuantity(request.orderQuantity())) {
             throw new IllegalArgumentException(
                     String.format("주문 가능한 수량을 초과하였습니다. 주문 가능한 수량 : %d개", stock.getTotalQuantity()));
         }

--- a/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
+++ b/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
@@ -26,12 +26,6 @@ public class ProductController {
         this.productService = productService;
     }
 
-    @PostMapping("/products")
-    public ResponseEntity<Long> createProduct(@RequestBody CreateProductRequest request) {
-        Long productId = productService.createProduct(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(productId);
-    }
-
     @GetMapping("/products/{id}")
     public ResponseEntity<ProductResponse> getProduct(@PathVariable Long id) {
         return ResponseEntity.status(HttpStatus.OK).body(productService.getProduct(id));

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/CreateProductRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/CreateProductRequest.java
@@ -5,8 +5,8 @@ import cholog.wiseshop.db.stock.Stock;
 
 public record CreateProductRequest(String name,
                                    String description,
-                                   Integer price,
-                                   Integer totalQuantity) {
+                                   int price,
+                                   int totalQuantity) {
 
     public Product from() {
         return new Product(

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/CreateProductRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/CreateProductRequest.java
@@ -1,6 +1,7 @@
 package cholog.wiseshop.api.product.dto.request;
 
 import cholog.wiseshop.db.product.Product;
+import cholog.wiseshop.db.stock.Stock;
 
 public record CreateProductRequest(String name,
                                    String description,
@@ -11,7 +12,8 @@ public record CreateProductRequest(String name,
         return new Product(
                 name,
                 description,
-                price
+                price,
+                new Stock(totalQuantity)
         );
     }
 }

--- a/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
+++ b/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
@@ -9,7 +9,6 @@ import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
 import cholog.wiseshop.db.stock.Stock;
-import java.time.LocalDateTime;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -1,17 +1,13 @@
 package cholog.wiseshop.db.campaign;
 
-import cholog.wiseshop.db.product.Product;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 
 @Entity
@@ -20,10 +16,6 @@ public class Campaign {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @OneToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "PRODUCT_ID")
-    private Product product;
 
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
@@ -39,8 +31,7 @@ public class Campaign {
 
     private CampaignState state;
 
-    public Campaign(Product product, LocalDateTime startDate, LocalDateTime endDate, int goalQuantity) {
-        this.product = product;
+    public Campaign(LocalDateTime startDate, LocalDateTime endDate, int goalQuantity) {
         this.startDate = startDate;
         this.endDate = endDate;
         this.goalQuantity = goalQuantity;
@@ -56,10 +47,6 @@ public class Campaign {
 
     public Long getId() {
         return id;
-    }
-
-    public Product getProduct() {
-        return product;
     }
 
     public LocalDateTime getStartDate() {

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -45,6 +45,13 @@ public class Campaign {
         this.state = state;
     }
 
+    public void increaseSoldQuantity(int orderQuantity) {
+        soldQuantity -= orderQuantity;
+        if (soldQuantity - orderQuantity == 0) {
+            this.state = CampaignState.SUCCESS;
+        }
+    }
+
     public Long getId() {
         return id;
     }
@@ -63,5 +70,9 @@ public class Campaign {
 
     public CampaignState getState() {
         return state;
+    }
+
+    public boolean isInProgress() {
+        return state.equals(CampaignState.SUCCESS);
     }
 }

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -25,9 +25,9 @@ public class Campaign {
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime endDate;
 
-    private int goalQuantity;
+    private Integer goalQuantity;
 
-    private int soldQuantity;
+    private Integer soldQuantity;
 
     private CampaignState state;
 
@@ -57,7 +57,7 @@ public class Campaign {
         return endDate;
     }
 
-    public int getGoalQuantity() {
+    public Integer getGoalQuantity() {
         return goalQuantity;
     }
 

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -73,6 +73,6 @@ public class Campaign {
     }
 
     public boolean isInProgress() {
-        return state.equals(CampaignState.SUCCESS);
+        return state.equals(CampaignState.IN_PROGRESS);
     }
 }

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -25,9 +25,9 @@ public class Campaign {
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime endDate;
 
-    private Integer goalQuantity;
+    private int goalQuantity;
 
-    private Integer soldQuantity;
+    private int soldQuantity;
 
     private CampaignState state;
 
@@ -57,7 +57,7 @@ public class Campaign {
         return endDate;
     }
 
-    public Integer getGoalQuantity() {
+    public int getGoalQuantity() {
         return goalQuantity;
     }
 

--- a/src/main/java/cholog/wiseshop/db/product/Product.java
+++ b/src/main/java/cholog/wiseshop/db/product/Product.java
@@ -1,5 +1,6 @@
 package cholog.wiseshop.db.product;
 
+import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.stock.Stock;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -8,8 +9,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
-import org.hibernate.annotations.Cascade;
 
 @Entity
 public class Product {
@@ -23,6 +24,10 @@ public class Product {
     private String description;
 
     private int price;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "CAMPAIGN_ID")
+    private Campaign campaign;
 
     @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     @JoinColumn(name = "STOCK_ID")
@@ -48,6 +53,10 @@ public class Product {
     public void modifyProduct(String name, String description) {
         this.name = name;
         this.description = description;
+    }
+
+    public void addCampaign(Campaign campaign) {
+        this.campaign = campaign;
     }
 
     public void modifyPrice(int price) {

--- a/src/main/java/cholog/wiseshop/db/product/Product.java
+++ b/src/main/java/cholog/wiseshop/db/product/Product.java
@@ -79,6 +79,10 @@ public class Product {
         return price;
     }
 
+    public Campaign getCampaign() {
+        return campaign;
+    }
+
     public Stock getStock() {
         return stock;
     }

--- a/src/main/java/cholog/wiseshop/db/product/ProductRepository.java
+++ b/src/main/java/cholog/wiseshop/db/product/ProductRepository.java
@@ -1,6 +1,12 @@
 package cholog.wiseshop.db.product;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    @Query("SELECT p FROM Product p JOIN FETCH p.stock JOIN FETCH p.campaign WHERE p.campaign.id = :campaignId")
+    List<Product> findProductsByCampaignId(@Param("campaignId") Long campaignId);
 }

--- a/src/main/java/cholog/wiseshop/db/stock/Stock.java
+++ b/src/main/java/cholog/wiseshop/db/stock/Stock.java
@@ -43,10 +43,6 @@ public class Stock {
     }
 
     public boolean hasQuantity(int orderQuantity) {
-        if (totalQuantity < orderQuantity) {
-            throw new IllegalArgumentException(
-                    "주문 가능 수량을 초과하였습니다. 주문 가능한 수량은 " + totalQuantity + "개 입니다.");
-        }
-        return true;
+        return totalQuantity >= orderQuantity;
     }
 }

--- a/src/main/java/cholog/wiseshop/db/stock/Stock.java
+++ b/src/main/java/cholog/wiseshop/db/stock/Stock.java
@@ -14,9 +14,9 @@ public class Stock {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Integer totalQuantity;
+    private int totalQuantity;
 
-    public Stock(Integer totalQuantity) {
+    public Stock(int totalQuantity) {
         this.totalQuantity = totalQuantity;
     }
 
@@ -27,14 +27,26 @@ public class Stock {
         return id;
     }
 
-    public Integer getTotalQuantity() {
+    public int getTotalQuantity() {
         return totalQuantity;
     }
 
-    public void modifyTotalQuantity(Integer modifyQuantity) {
+    public void modifyTotalQuantity(int modifyQuantity) {
         if (modifyQuantity < MINIMUM_QUANTITY) {
             throw new IllegalArgumentException("재고 수량은 최소 1개 이상이어야 합니다.");
         }
         this.totalQuantity = modifyQuantity;
+    }
+
+    public void reduceQuantity(int orderQuantity) {
+        this.totalQuantity -= orderQuantity;
+    }
+
+    public boolean hasQuantity(int orderQuantity) {
+        if (totalQuantity < orderQuantity) {
+            throw new IllegalArgumentException(
+                    "주문 가능 수량을 초과하였습니다. 주문 가능한 수량은 " + totalQuantity + "개 입니다.");
+        }
+        return true;
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -3,8 +3,10 @@ package cholog.wiseshop.domain.campaign;
 import static cholog.wiseshop.domain.product.ProductRepositoryTest.getCreateProductRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
+import cholog.wiseshop.api.campaign.dto.response.ReadCampaignResponse;
 import cholog.wiseshop.api.campaign.service.CampaignService;
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.api.product.service.ProductService;
@@ -63,46 +65,51 @@ public class CampaignServiceTest {
         assertThat(findCampaign.getState()).isEqualTo(CampaignState.WAITING);
     }
 
-//
-//    @Test
-//    void 캠페인_조회하기() {
-//        //given
-//        CreateProductRequest request = getCreateProductRequest();
-//        Long productId = productService.createProduct(request);
-//
-//        //when
-//        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
-//        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
-//        int goalQuantity = 5;
-//
-//        Long campaignId = campaignService.createCampaign(
-//                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
-//        ReadCampaignResponse response = campaignService.readCampaign(campaignId);
-//
-//        //then
-//        assertThat(response.campaignId()).isEqualTo(campaignId);
-//        assertThat(response.productId()).isEqualTo(productId);
-//    }
-//
-//    @Test
-//    void 캠페인_조회하기_예외_잘못된_캠페인ID() {
-//        //given
-//        CreateProductRequest request = getCreateProductRequest();
-//        Long productId = productService.createProduct(request);
-//
-//        //when
-//        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
-//        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
-//        int goalQuantity = 5;
-//
-//        Long campaignId = campaignService.createCampaign(
-//                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
-//        Long wrongId = campaignId + 1;
-//
-//        //then
-//        assertThatThrownBy(() -> campaignService.readCampaign(wrongId))
-//                .isInstanceOf(IllegalArgumentException.class);
-//    }
+
+    @Test
+    void 캠페인_조회하기() {
+        //given
+        CreateProductRequest request = getCreateProductRequest();
+        productService.createProduct(request);
+
+        //when
+        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+        int goalQuantity = 5;
+
+        Long campaignId = campaignService.createCampaign(
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+        ReadCampaignResponse response = campaignService.readCampaign(campaignId);
+
+        //then
+        assertAll(
+                () -> assertThat(response.campaignId()).isEqualTo(campaignId),
+                () -> assertThat(response.product().name()).isEqualTo(request.name()),
+                () -> assertThat(response.product().description()).isEqualTo(request.description()),
+                () -> assertThat(response.product().price()).isEqualTo(request.price()),
+                () -> assertThat(response.product().totalQuantity()).isEqualTo(request.totalQuantity())
+        );
+    }
+
+    @Test
+    void 캠페인_조회하기_예외_잘못된_캠페인ID() {
+        //given
+        CreateProductRequest request = getCreateProductRequest();
+        productService.createProduct(request);
+
+        //when
+        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+        int goalQuantity = 5;
+
+        Long campaignId = campaignService.createCampaign(
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+        Long wrongId = campaignId + 1;
+
+        //then
+        assertThatThrownBy(() -> campaignService.readCampaign(wrongId))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
 //
 //    @Test
 //    void 캠페인_시작_상태_변경_성공() {

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -2,6 +2,7 @@ package cholog.wiseshop.domain.campaign;
 
 import static cholog.wiseshop.domain.product.ProductRepositoryTest.getCreateProductRequest;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
 import cholog.wiseshop.api.campaign.service.CampaignService;
@@ -62,19 +63,6 @@ public class CampaignServiceTest {
         assertThat(findCampaign.getState()).isEqualTo(CampaignState.WAITING);
     }
 
-//    @Test
-//    void 캠페인_추가하기_예외_잘못된_상품ID() {
-//        //given
-//        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
-//        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
-//        int goalQuantity = 5;
-//        Long productId = 1L;
-//
-//        //when & then
-//        assertThatThrownBy(() -> campaignService.createCampaign(
-//                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId)))
-//                .isInstanceOf(IllegalArgumentException.class);
-//    }
 //
 //    @Test
 //    void 캠페인_조회하기() {

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -47,7 +47,7 @@ public class CampaignServiceTest {
         //when
         LocalDateTime startDate = LocalDateTime.now().plusMinutes(1);
         LocalDateTime endDate = LocalDateTime.now().plusMinutes(2);
-        int goalQuantity = 5;
+        Integer goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
                 new CreateCampaignRequest(startDate, endDate, goalQuantity, request));

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -16,6 +16,8 @@ import cholog.wiseshop.db.campaign.CampaignState;
 import cholog.wiseshop.db.product.ProductRepository;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,8 +40,8 @@ public class CampaignServiceTest {
 
     @BeforeEach
     public void cleanUp() {
-        campaignRepository.deleteAll();
         productRepository.deleteAll();
+        campaignRepository.deleteAll();
     }
 
     @Test
@@ -110,73 +112,73 @@ public class CampaignServiceTest {
         assertThatThrownBy(() -> campaignService.readCampaign(wrongId))
                 .isInstanceOf(IllegalArgumentException.class);
     }
-//
-//    @Test
-//    void 캠페인_시작_상태_변경_성공() {
-//        //given
-//        CreateProductRequest request = getCreateProductRequest();
-//        Long productId = productService.createProduct(request);
-//
-//        //when
-//        LocalDateTime startDate = LocalDateTime.now().plusSeconds(1);
-//        LocalDateTime endDate = LocalDateTime.now().plusSeconds(10);
-//        int goalQuantity = 5;
-//
-//        Long campaignId = campaignService.createCampaign(
-//                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
-//        Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
-//
-//        // then
-//        Awaitility.await()
-//                .atLeast(1, TimeUnit.SECONDS)
-//                .untilAsserted(() -> {
-//                    Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
-//                            .orElseThrow();
-//                    assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.IN_PROGRESS);
-//                });
-//    }
-//
-//    @Test
-//    void 캠페인_실패_상태_변경_성공() {
-//        //given
-//        CreateProductRequest request = getCreateProductRequest();
-//        Long productId = productService.createProduct(request);
-//
-//        //when
-//        LocalDateTime startDate = LocalDateTime.now();
-//        LocalDateTime endDate = LocalDateTime.now().plusSeconds(1);
-//        int goalQuantity = 5;
-//
-//        Long campaignId = campaignService.createCampaign(
-//                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
-//        Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
-//
-//        // then
-//        Awaitility.await()
-//                .atLeast(1, TimeUnit.SECONDS)
-//                .untilAsserted(() -> {
-//                    Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
-//                            .orElseThrow();
-//                    assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.FAILED);
-//                });
-//    }
-//
-//    @Test
-//    void 캠페인이_시작됐는지_확인() {
-//        //given
-//        CreateProductRequest request = getCreateProductRequest();
-//        Long productId = productService.createProduct(request);
-//
-//        //when
-//        LocalDateTime startDate = LocalDateTime.now().plusSeconds(1);
-//        LocalDateTime endDate = LocalDateTime.now().plusSeconds(10);
-//        int goalQuantity = 5;
-//
-//        Long campaignId = campaignService.createCampaign(
-//                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
-//        // then
-//        Awaitility.await()
-//                .atLeast(1, TimeUnit.SECONDS)
-//                .untilAsserted(() -> assertThat(campaignService.isStarted(campaignId)).isTrue());
-//    }
+
+    @Test
+    void 캠페인_시작_상태_변경_성공() {
+        //given
+        CreateProductRequest request = getCreateProductRequest();
+        productService.createProduct(request);
+
+        //when
+        LocalDateTime startDate = LocalDateTime.now().plusSeconds(1);
+        LocalDateTime endDate = LocalDateTime.now().plusSeconds(10);
+        int goalQuantity = 5;
+
+        Long campaignId = campaignService.createCampaign(
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+        Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
+
+        // then
+        Awaitility.await()
+                .atLeast(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
+                            .orElseThrow();
+                    assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.IN_PROGRESS);
+                });
+    }
+
+    @Test
+    void 캠페인_실패_상태_변경_성공() {
+        //given
+        CreateProductRequest request = getCreateProductRequest();
+        productService.createProduct(request);
+
+        //when
+        LocalDateTime startDate = LocalDateTime.now();
+        LocalDateTime endDate = LocalDateTime.now().plusSeconds(1);
+        int goalQuantity = 5;
+
+        Long campaignId = campaignService.createCampaign(
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+        Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
+
+        // then
+        Awaitility.await()
+                .atLeast(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
+                            .orElseThrow();
+                    assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.FAILED);
+                });
+    }
+
+    @Test
+    void 캠페인이_시작됐는지_확인() {
+        //given
+        CreateProductRequest request = getCreateProductRequest();
+        productService.createProduct(request);
+
+        //when
+        LocalDateTime startDate = LocalDateTime.now().plusSeconds(1);
+        LocalDateTime endDate = LocalDateTime.now().plusSeconds(10);
+        int goalQuantity = 5;
+
+        Long campaignId = campaignService.createCampaign(
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+        // then
+        Awaitility.await()
+                .atLeast(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(campaignService.isStarted(campaignId)).isTrue());
+    }
 }

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -2,10 +2,8 @@ package cholog.wiseshop.domain.campaign;
 
 import static cholog.wiseshop.domain.product.ProductRepositoryTest.getCreateProductRequest;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
-import cholog.wiseshop.api.campaign.dto.response.ReadCampaignResponse;
 import cholog.wiseshop.api.campaign.service.CampaignService;
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.api.product.service.ProductService;
@@ -14,8 +12,7 @@ import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.campaign.CampaignState;
 import cholog.wiseshop.db.product.ProductRepository;
 import java.time.LocalDateTime;
-import java.util.concurrent.TimeUnit;
-import org.awaitility.Awaitility;
+import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,145 +44,144 @@ public class CampaignServiceTest {
         //given
         CreateProductRequest request = getCreateProductRequest();
 
-        Long productId = productService.createProduct(request);
-
         //when
-        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30, 10);
-        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30, 10);
+        LocalDateTime startDate = LocalDateTime.now().plusMinutes(1);
+        LocalDateTime endDate = LocalDateTime.now().plusMinutes(2);
         int goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
         Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
 
         //then
-        assertThat(findCampaign.getProduct().getId()).isEqualTo(productId);
-        assertThat(findCampaign.getStartDate().isEqual(startDate)).isTrue();
-        assertThat(findCampaign.getEndDate().isEqual(endDate)).isTrue();
+        assertThat(findCampaign.getStartDate().truncatedTo(ChronoUnit.SECONDS))
+                .isEqualTo(startDate.truncatedTo(ChronoUnit.SECONDS));
+        assertThat(findCampaign.getEndDate().truncatedTo(ChronoUnit.SECONDS))
+                .isEqualTo(endDate.truncatedTo(ChronoUnit.SECONDS));
         assertThat(findCampaign.getGoalQuantity()).isEqualTo(goalQuantity);
         assertThat(findCampaign.getState()).isEqualTo(CampaignState.WAITING);
     }
 
-    @Test
-    void 캠페인_추가하기_예외_잘못된_상품ID() {
-        //given
-        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
-        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
-        int goalQuantity = 5;
-        Long productId = 1L;
-
-        //when & then
-        assertThatThrownBy(() -> campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId)))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void 캠페인_조회하기() {
-        //given
-        CreateProductRequest request = getCreateProductRequest();
-        Long productId = productService.createProduct(request);
-
-        //when
-        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
-        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
-        int goalQuantity = 5;
-
-        Long campaignId = campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
-        ReadCampaignResponse response = campaignService.readCampaign(campaignId);
-
-        //then
-        assertThat(response.campaignId()).isEqualTo(campaignId);
-        assertThat(response.productId()).isEqualTo(productId);
-    }
-
-    @Test
-    void 캠페인_조회하기_예외_잘못된_캠페인ID() {
-        //given
-        CreateProductRequest request = getCreateProductRequest();
-        Long productId = productService.createProduct(request);
-
-        //when
-        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
-        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
-        int goalQuantity = 5;
-
-        Long campaignId = campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
-        Long wrongId = campaignId + 1;
-
-        //then
-        assertThatThrownBy(() -> campaignService.readCampaign(wrongId))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void 캠페인_시작_상태_변경_성공() {
-        //given
-        CreateProductRequest request = getCreateProductRequest();
-        Long productId = productService.createProduct(request);
-
-        //when
-        LocalDateTime startDate = LocalDateTime.now().plusSeconds(1);
-        LocalDateTime endDate = LocalDateTime.now().plusSeconds(10);
-        int goalQuantity = 5;
-
-        Long campaignId = campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
-        Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
-
-        // then
-        Awaitility.await()
-                .atLeast(1, TimeUnit.SECONDS)
-                .untilAsserted(() -> {
-                    Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
-                            .orElseThrow();
-                    assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.IN_PROGRESS);
-                });
-    }
-
-    @Test
-    void 캠페인_실패_상태_변경_성공() {
-        //given
-        CreateProductRequest request = getCreateProductRequest();
-        Long productId = productService.createProduct(request);
-
-        //when
-        LocalDateTime startDate = LocalDateTime.now();
-        LocalDateTime endDate = LocalDateTime.now().plusSeconds(1);
-        int goalQuantity = 5;
-
-        Long campaignId = campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
-        Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
-
-        // then
-        Awaitility.await()
-                .atLeast(1, TimeUnit.SECONDS)
-                .untilAsserted(() -> {
-                    Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
-                            .orElseThrow();
-                    assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.FAILED);
-                });
-    }
-
-    @Test
-    void 캠페인이_시작됐는지_확인() {
-        //given
-        CreateProductRequest request = getCreateProductRequest();
-        Long productId = productService.createProduct(request);
-
-        //when
-        LocalDateTime startDate = LocalDateTime.now().plusSeconds(1);
-        LocalDateTime endDate = LocalDateTime.now().plusSeconds(10);
-        int goalQuantity = 5;
-
-        Long campaignId = campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
-        // then
-        Awaitility.await()
-                .atLeast(1, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertThat(campaignService.isStarted(campaignId)).isTrue());
-    }
+//    @Test
+//    void 캠페인_추가하기_예외_잘못된_상품ID() {
+//        //given
+//        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+//        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+//        int goalQuantity = 5;
+//        Long productId = 1L;
+//
+//        //when & then
+//        assertThatThrownBy(() -> campaignService.createCampaign(
+//                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId)))
+//                .isInstanceOf(IllegalArgumentException.class);
+//    }
+//
+//    @Test
+//    void 캠페인_조회하기() {
+//        //given
+//        CreateProductRequest request = getCreateProductRequest();
+//        Long productId = productService.createProduct(request);
+//
+//        //when
+//        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+//        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+//        int goalQuantity = 5;
+//
+//        Long campaignId = campaignService.createCampaign(
+//                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
+//        ReadCampaignResponse response = campaignService.readCampaign(campaignId);
+//
+//        //then
+//        assertThat(response.campaignId()).isEqualTo(campaignId);
+//        assertThat(response.productId()).isEqualTo(productId);
+//    }
+//
+//    @Test
+//    void 캠페인_조회하기_예외_잘못된_캠페인ID() {
+//        //given
+//        CreateProductRequest request = getCreateProductRequest();
+//        Long productId = productService.createProduct(request);
+//
+//        //when
+//        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+//        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+//        int goalQuantity = 5;
+//
+//        Long campaignId = campaignService.createCampaign(
+//                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
+//        Long wrongId = campaignId + 1;
+//
+//        //then
+//        assertThatThrownBy(() -> campaignService.readCampaign(wrongId))
+//                .isInstanceOf(IllegalArgumentException.class);
+//    }
+//
+//    @Test
+//    void 캠페인_시작_상태_변경_성공() {
+//        //given
+//        CreateProductRequest request = getCreateProductRequest();
+//        Long productId = productService.createProduct(request);
+//
+//        //when
+//        LocalDateTime startDate = LocalDateTime.now().plusSeconds(1);
+//        LocalDateTime endDate = LocalDateTime.now().plusSeconds(10);
+//        int goalQuantity = 5;
+//
+//        Long campaignId = campaignService.createCampaign(
+//                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
+//        Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
+//
+//        // then
+//        Awaitility.await()
+//                .atLeast(1, TimeUnit.SECONDS)
+//                .untilAsserted(() -> {
+//                    Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
+//                            .orElseThrow();
+//                    assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.IN_PROGRESS);
+//                });
+//    }
+//
+//    @Test
+//    void 캠페인_실패_상태_변경_성공() {
+//        //given
+//        CreateProductRequest request = getCreateProductRequest();
+//        Long productId = productService.createProduct(request);
+//
+//        //when
+//        LocalDateTime startDate = LocalDateTime.now();
+//        LocalDateTime endDate = LocalDateTime.now().plusSeconds(1);
+//        int goalQuantity = 5;
+//
+//        Long campaignId = campaignService.createCampaign(
+//                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
+//        Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
+//
+//        // then
+//        Awaitility.await()
+//                .atLeast(1, TimeUnit.SECONDS)
+//                .untilAsserted(() -> {
+//                    Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
+//                            .orElseThrow();
+//                    assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.FAILED);
+//                });
+//    }
+//
+//    @Test
+//    void 캠페인이_시작됐는지_확인() {
+//        //given
+//        CreateProductRequest request = getCreateProductRequest();
+//        Long productId = productService.createProduct(request);
+//
+//        //when
+//        LocalDateTime startDate = LocalDateTime.now().plusSeconds(1);
+//        LocalDateTime endDate = LocalDateTime.now().plusSeconds(10);
+//        int goalQuantity = 5;
+//
+//        Long campaignId = campaignService.createCampaign(
+//                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
+//        // then
+//        Awaitility.await()
+//                .atLeast(1, TimeUnit.SECONDS)
+//                .untilAsserted(() -> assertThat(campaignService.isStarted(campaignId)).isTrue());
+//    }
 }

--- a/src/test/java/cholog/wiseshop/domain/order/OrderServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/order/OrderServiceTest.java
@@ -46,7 +46,7 @@ public class OrderServiceTest {
     void setUp() {
         request = getCreateProductRequest();
 
-        LocalDateTime startDate = LocalDateTime.now().plus(10, ChronoUnit.MILLIS);
+        LocalDateTime startDate = LocalDateTime.now();
         LocalDateTime endDate = LocalDateTime.now().plusMinutes(5);
         int goalQuantity = 5;
 

--- a/src/test/java/cholog/wiseshop/domain/order/OrderServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/order/OrderServiceTest.java
@@ -1,0 +1,78 @@
+package cholog.wiseshop.domain.order;
+
+import static cholog.wiseshop.domain.product.ProductRepositoryTest.getCreateProductRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
+import cholog.wiseshop.api.campaign.service.CampaignService;
+import cholog.wiseshop.api.order.dto.request.CreateOrderRequest;
+import cholog.wiseshop.api.order.dto.response.OrderResponse;
+import cholog.wiseshop.api.order.service.OrderService;
+import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
+import cholog.wiseshop.db.campaign.CampaignRepository;
+import cholog.wiseshop.db.order.OrderRepository;
+import cholog.wiseshop.db.product.ProductRepository;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class OrderServiceTest {
+
+    @Autowired
+    private CampaignService campaignService;
+
+    @Autowired
+    private CampaignRepository campaignRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    private Long campaignId;
+
+    private CreateProductRequest request;
+
+    @BeforeEach
+    void setUp() {
+        request = getCreateProductRequest();
+
+        LocalDateTime startDate = LocalDateTime.now().plus(10, ChronoUnit.MILLIS);
+        LocalDateTime endDate = LocalDateTime.now().plusMinutes(5);
+        int goalQuantity = 5;
+
+        campaignId = campaignService.createCampaign(
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+    }
+
+    @AfterEach
+    void cleanUp() {
+        orderRepository.deleteAll();
+        productRepository.deleteAll();
+        campaignRepository.deleteAll();
+    }
+
+    @Test
+    void 주문_생성_성공() {
+        //given
+        int orderQuantity = 5;
+        CreateOrderRequest orderRequest = new CreateOrderRequest(campaignId, orderQuantity);
+
+        //when
+        Long orderId = orderService.createOrder(orderRequest);
+        OrderResponse response = orderService.readOrder(orderId);
+
+        //then
+        assertThat(response.productName()).isEqualTo(request.name());
+        assertThat(response.count()).isEqualTo(orderQuantity);
+    }
+}

--- a/src/test/java/cholog/wiseshop/domain/product/ProductRepositoryTest.java
+++ b/src/test/java/cholog/wiseshop/domain/product/ProductRepositoryTest.java
@@ -123,8 +123,8 @@ public class ProductRepositoryTest {
     public static CreateProductRequest getCreateProductRequest() {
         String name = "보약";
         String description = "먹으면 기분이 좋아져요.";
-        Integer price = 10000;
-        Integer totalQuantity = 5;
+        int price = 10000;
+        int totalQuantity = 5;
 
         return new CreateProductRequest(name, description, price, totalQuantity);
     }

--- a/src/test/java/cholog/wiseshop/domain/product/ProductRepositoryTest.java
+++ b/src/test/java/cholog/wiseshop/domain/product/ProductRepositoryTest.java
@@ -1,10 +1,17 @@
 package cholog.wiseshop.domain.product;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
+import cholog.wiseshop.db.campaign.Campaign;
+import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
+import cholog.wiseshop.db.stock.Stock;
+import cholog.wiseshop.db.stock.StockRepository;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +23,12 @@ public class ProductRepositoryTest {
     @Autowired
     private ProductRepository productRepository;
 
+    @Autowired
+    private CampaignRepository campaignRepository;
+
+    @Autowired
+    private StockRepository stockRepository;
+
     private static CreateProductRequest request;
 
     @BeforeEach
@@ -25,7 +38,32 @@ public class ProductRepositoryTest {
     }
 
     @Test
-    public void 상품_저장_조회하기() {
+    void 상품_재고_캠페인_저장하기() {
+        // given
+        LocalDateTime startDate = LocalDateTime.now().plusMinutes(1);
+        LocalDateTime endDate = LocalDateTime.now().plusMinutes(2);
+        Integer goalQuantity = 5;
+        Campaign campaign = campaignRepository.save(new Campaign(startDate, endDate, goalQuantity));
+
+        Product product = productRepository.save(request.from());
+        product.addCampaign(campaign);
+
+        // when
+        List<Product> products = productRepository.findProductsByCampaignId(campaign.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(products).hasSize(1),
+                () -> assertThat(products.get(0).getName()).isEqualTo(request.name()),
+                () -> assertThat(products.get(0).getDescription()).isEqualTo(request.description()),
+                () -> assertThat(products.get(0).getPrice()).isEqualTo(request.price()),
+                () -> assertThat(products.get(0).getStock().getTotalQuantity()).isEqualTo(request.totalQuantity()),
+                () -> assertThat(products.get(0).getCampaign().getId()).isEqualTo(campaign.getId())
+        );
+    }
+
+    @Test
+    void 상품_저장_조회하기() {
         // when
         Product savedProduct = productRepository.save(request.from());
 
@@ -38,7 +76,7 @@ public class ProductRepositoryTest {
     }
 
     @Test
-    public void 상품_이름_설명글_수정하기() {
+    void 상품_이름_설명글_수정하기() {
         // given
         String modifiedName = "보약2";
         String modifiedDescription = "먹으면 기분이 안좋아져요.";
@@ -56,7 +94,7 @@ public class ProductRepositoryTest {
     }
 
     @Test
-    public void 상품_가격_수정하기() {
+    void 상품_가격_수정하기() {
         // given
         int modifiedPrice = 20000;
 
@@ -72,7 +110,7 @@ public class ProductRepositoryTest {
     }
 
     @Test
-    public void 상품_삭제하기() {
+    void 상품_삭제하기() {
         // when
         Product createdProduct = productRepository.save(request.from());
 
@@ -81,6 +119,7 @@ public class ProductRepositoryTest {
         // then
         assertThat(productRepository.findById(createdProduct.getId())).isEmpty();
     }
+
 
     public static CreateProductRequest getCreateProductRequest() {
         String name = "보약";

--- a/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
@@ -44,8 +44,8 @@ public class ProductServiceTest {
 
     @BeforeEach
     void cleanUp() {
-        campaignRepository.deleteAll();
         productRepository.deleteAll();
+        campaignRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
@@ -188,7 +188,7 @@ public class ProductServiceTest {
         int goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
         Integer modifyQuantity = 1;
 
         // when
@@ -218,7 +218,7 @@ public class ProductServiceTest {
         int goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, productId));
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
         Integer modifyQuantity = 0;
 
         // when

--- a/src/test/java/cholog/wiseshop/web/campaign/CampaignControllerTest.java
+++ b/src/test/java/cholog/wiseshop/web/campaign/CampaignControllerTest.java
@@ -1,5 +1,6 @@
 package cholog.wiseshop.web.campaign;
 
+import static cholog.wiseshop.domain.product.ProductRepositoryTest.getCreateProductRequest;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -9,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
 import cholog.wiseshop.api.campaign.service.CampaignService;
+import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
@@ -76,17 +78,12 @@ public class CampaignControllerTest {
     @Test
     void 캠페인_생성하기() throws Exception {
         // given
-        String name = "보약";
-        String description = "먹으면 기분이 좋아져요.";
-        int price = 10000;
-        Product product = new Product(name, description, price);
-        Product savedProduct = productRepository.save(product);
-
         LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
         LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
         int goalQuantity = 5;
-        CreateCampaignRequest request = new CreateCampaignRequest(
-                startDate, endDate, goalQuantity, savedProduct.getId());
+
+        CreateProductRequest productRequest = getCreateProductRequest();
+        CreateCampaignRequest request = new CreateCampaignRequest(startDate, endDate, goalQuantity, productRequest);
 
         String url = "http://localhost:" + port + "/api/v1/campaigns";
 
@@ -100,30 +97,30 @@ public class CampaignControllerTest {
                 .andDo(print());
     }
 
-    @Test
-    void 캠페인_조회하기() throws Exception {
-        // given
-        String name = "보약";
-        String description = "먹으면 기분이 좋아져요.";
-        int price = 10000;
-        Product product = new Product(name, description, price);
-        Product savedProduct = productRepository.save(product);
-
-        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
-        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
-        int goalQuantity = 5;
-        CreateCampaignRequest request = new CreateCampaignRequest(
-                startDate, endDate, goalQuantity, savedProduct.getId());
-        Long campaignId = campaignService.createCampaign(request);
-
-        String url = "http://localhost:" + port + "/api/v1/campaigns/" + campaignId;
-
-        // when & then
-        mockMvc.perform(get(url)
-                        .characterEncoding("utf-8"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.campaignId").value(campaignId))
-                .andExpect(jsonPath("$.productId").value(savedProduct.getId()))
-                .andDo(print());
-    }
+//    @Test
+//    void 캠페인_조회하기() throws Exception {
+//        // given
+//        String name = "보약";
+//        String description = "먹으면 기분이 좋아져요.";
+//        int price = 10000;
+//        Product product = new Product(name, description, price);
+//        Product savedProduct = productRepository.save(product);
+//
+//        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+//        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+//        int goalQuantity = 5;
+//        CreateCampaignRequest request = new CreateCampaignRequest(
+//                startDate, endDate, goalQuantity, savedProduct.getId());
+//        Long campaignId = campaignService.createCampaign(request);
+//
+//        String url = "http://localhost:" + port + "/api/v1/campaigns/" + campaignId;
+//
+//        // when & then
+//        mockMvc.perform(get(url)
+//                        .characterEncoding("utf-8"))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.campaignId").value(campaignId))
+//                .andExpect(jsonPath("$.productId").value(savedProduct.getId()))
+//                .andDo(print());
+//    }
 }

--- a/src/test/java/cholog/wiseshop/web/campaign/CampaignControllerTest.java
+++ b/src/test/java/cholog/wiseshop/web/campaign/CampaignControllerTest.java
@@ -80,7 +80,7 @@ public class CampaignControllerTest {
         // given
         LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
         LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
-        int goalQuantity = 5;
+        Integer goalQuantity = 5;
 
         CreateProductRequest productRequest = getCreateProductRequest();
         CreateCampaignRequest request = new CreateCampaignRequest(startDate, endDate, goalQuantity, productRequest);
@@ -97,30 +97,34 @@ public class CampaignControllerTest {
                 .andDo(print());
     }
 
-//    @Test
-//    void 캠페인_조회하기() throws Exception {
-//        // given
-//        String name = "보약";
-//        String description = "먹으면 기분이 좋아져요.";
-//        int price = 10000;
-//        Product product = new Product(name, description, price);
-//        Product savedProduct = productRepository.save(product);
-//
-//        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
-//        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
-//        int goalQuantity = 5;
-//        CreateCampaignRequest request = new CreateCampaignRequest(
-//                startDate, endDate, goalQuantity, savedProduct.getId());
-//        Long campaignId = campaignService.createCampaign(request);
-//
-//        String url = "http://localhost:" + port + "/api/v1/campaigns/" + campaignId;
-//
-//        // when & then
-//        mockMvc.perform(get(url)
-//                        .characterEncoding("utf-8"))
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.campaignId").value(campaignId))
-//                .andExpect(jsonPath("$.productId").value(savedProduct.getId()))
-//                .andDo(print());
-//    }
+    @Test
+    void 캠페인_조회하기() throws Exception {
+        // given
+        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+        Integer goalQuantity = 5;
+
+        CreateProductRequest productRequest = getCreateProductRequest();
+        CreateCampaignRequest request = new CreateCampaignRequest(startDate, endDate, goalQuantity, productRequest);
+
+        String postUrl = "http://localhost:" + port + "/api/v1/campaigns";
+        mockMvc.perform(post(postUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(content().string("1"))
+                .andDo(print());
+        String getUrl = "http://localhost:" + port + "/api/v1/campaigns/" + 1;
+
+        // when & then
+        mockMvc.perform(get(getUrl)
+                        .characterEncoding("utf-8"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.campaignId").value(1))
+                .andExpect(jsonPath("$.startDate").value(startDate.toString()))
+                .andExpect(jsonPath("$.endDate").value(endDate.toString()))
+                .andExpect(jsonPath("$.goalQuantity").value(goalQuantity))
+                .andDo(print());
+    }
 }

--- a/src/test/java/cholog/wiseshop/web/product/ProductControllerTest.java
+++ b/src/test/java/cholog/wiseshop/web/product/ProductControllerTest.java
@@ -1,21 +1,17 @@
 package cholog.wiseshop.web.product;
 
-import static cholog.wiseshop.domain.product.ProductRepositoryTest.getCreateProductRequest;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductPriceRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
+import cholog.wiseshop.db.stock.Stock;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.AfterEach;
@@ -27,7 +23,6 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
@@ -50,13 +45,26 @@ public class ProductControllerTest {
     @LocalServerPort
     private int port;
 
+    private static Product product;
+
     @BeforeEach
     public void setUp() {
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(context)
                 .build();
 
-        productRepository.deleteAll();
+        product = makeTestProduct();
+        productRepository.save(product);
+    }
+
+    private static Product makeTestProduct() {
+        String name = "보약2";
+        String description = "먹으면 기분이 좋아지지 않아요.";
+        int price = 50000;
+        Integer totalQuantity = 5;
+
+        Stock stock = new Stock(totalQuantity);
+        return new Product(name, description, price, stock);
     }
 
     @AfterEach
@@ -64,57 +72,21 @@ public class ProductControllerTest {
         this.entityManager
                 .createNativeQuery("ALTER TABLE product ALTER COLUMN `id` RESTART WITH 1")
                 .executeUpdate();
-
-    }
-
-    @Test
-    public void 상품_생성하기() throws Exception {
-        // given
-        CreateProductRequest request = getCreateProductRequest();
-        String url = "http://localhost:" + port + "/api/v1/products";
-
-        // when
-        mockMvc.perform(post(url)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .characterEncoding("utf-8")
-                        .content(new ObjectMapper().writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(content().string("1"))
-                .andDo(print());
-
-        // then
-        Product product = productRepository.findById(1L).orElseThrow();
-        assertThat(product.getName()).isEqualTo(request.name());
-        assertThat(product.getDescription()).isEqualTo(request.description());
-        assertThat(product.getPrice()).isEqualTo(request.price());
     }
 
     @Test
     public void 상품_조회하기() throws Exception {
-        // given
-        CreateProductRequest request = getCreateProductRequest();
-        String postUrl = "http://localhost:" + port + "/api/v1/products";
-        MvcResult mvcResult = mockMvc.perform(post(postUrl)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .characterEncoding("utf-8")
-                        .content(new ObjectMapper().writeValueAsString(request)))
-                .andReturn();
-        mvcResult.getResponse().getContentAsString();
-        ObjectMapper objectMapper = new ObjectMapper();
-        Long savedProductId = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), Long.TYPE);
-
         // when
-        String getUrl = "http://localhost:" + port + "/api/v1/products/" + savedProductId;
+        String getUrl = "http://localhost:" + port + "/api/v1/products/" + product.getId();
 
         //then
         mockMvc.perform(get(getUrl)
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding("utf-8"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.name").value(request.name()))
-                .andExpect(jsonPath("$.description").value(request.description()))
-                .andExpect(jsonPath("$.price").value(request.price()))
-                .andExpect(jsonPath("$.totalQuantity").value(request.totalQuantity()))
+                .andExpect(jsonPath("$.name").value(product.getName()))
+                .andExpect(jsonPath("$.description").value(product.getDescription()))
+                .andExpect(jsonPath("$.price").value(product.getPrice()))
                 .andDo(print());
     }
 
@@ -124,17 +96,9 @@ public class ProductControllerTest {
         String modifiedName = "보약3";
         String modifiedDescription = "먹으면 기분이 그냥그래요.";
 
-        String name = "보약2";
-        String description = "먹으면 기분이 좋아지지 않아요.";
-        int price = 50000;
-
-        Product product = new Product(name, description, price);
-
         // when
-        Product savedProduct = productRepository.save(product);
-
         ModifyProductRequest request =
-                new ModifyProductRequest(savedProduct.getId(), modifiedName, modifiedDescription);
+                new ModifyProductRequest(product.getId(), modifiedName, modifiedDescription);
 
         String url = "http://localhost:" + port + "/api/v1/products";
 
@@ -143,7 +107,8 @@ public class ProductControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(request))
                         .characterEncoding("utf-8"))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isNoContent())
+                .andDo(print());
     }
 
     @Test
@@ -151,16 +116,8 @@ public class ProductControllerTest {
         // given
         int modifiedPrice = 30000;
 
-        String name = "보약2";
-        String description = "먹으면 기분이 좋아지지 않아요.";
-        int price = 50000;
-
-        Product product = new Product(name, description, price);
-
         // when
-        Product savedProduct = productRepository.save(product);
-
-        ModifyProductPriceRequest request = new ModifyProductPriceRequest(savedProduct.getId(), modifiedPrice);
+        ModifyProductPriceRequest request = new ModifyProductPriceRequest(product.getId(), modifiedPrice);
 
         String url = "http://localhost:" + port + "/api/v1/products/price";
 
@@ -169,22 +126,14 @@ public class ProductControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(request))
                         .characterEncoding("utf-8"))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isNoContent())
+                .andDo(print());
     }
 
     @Test
     public void 상품_삭제하기() throws Exception {
-        // given
-        String name = "보약2";
-        String description = "먹으면 기분이 좋아지지 않아요.";
-        int price = 50000;
-
-        Product product = new Product(name, description, price);
-
         // when
-        Product savedProduct = productRepository.save(product);
-
-        String url = "http://localhost:" + port + "/api/v1/products/" + savedProduct.getId();
+        String url = "http://localhost:" + port + "/api/v1/products/" + product.getId();
 
         // then
         mockMvc.perform(delete(url)


### PR DESCRIPTION
## 작업내용
- 상품이 캠페인과 재고의 기본키를 외래키로 갖도록 하였습니다. 상품과 캠페인은 다대일 관계로 변경되었습니다.
- 캠페인 등록 API를 호출할 경우, `CampaignService`에서 `Stock`, `Product`를 함께 생성하여 영속성 컨텍스트에 저장합니다.
- 캠페인 등록 및 단건 조회 API의 명세가 변경되었습니다. (요청 / 응답 포맷 수정)

## 리뷰 포인트
- 캠페인 단건 조회 시, 캠페인 ID로 상품을 조회해야 하므로, `ProductRepository` 쪽에 JPQL 쿼리 메소드를 추가하였습니다. Fetch Join으로 한 번에 가져오도록 구현하였는데, 방법이 잘못되었거나 더 좋은 방법이 있다면 알려주세요 😄