### PR TITLE
feat: 주문 생성 시, 재고/캠페인 검증 및 수량 변경하는 로직 추가

### DIFF
--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -33,7 +33,8 @@ public class CampaignService {
     public CampaignService(CampaignRepository campaignRepository,
                            ProductRepository productRepository,
                            StockRepository stockRepository,
-                           ThreadPoolTaskScheduler scheduler, PlatformTransactionManager transactionManager) {
+                           ThreadPoolTaskScheduler scheduler,
+                           PlatformTransactionManager transactionManager) {
         this.campaignRepository = campaignRepository;
         this.productRepository = productRepository;
         this.stockRepository = stockRepository;

--- a/src/main/java/cholog/wiseshop/api/order/dto/request/CreateOrderRequest.java
+++ b/src/main/java/cholog/wiseshop/api/order/dto/request/CreateOrderRequest.java
@@ -3,11 +3,11 @@ package cholog.wiseshop.api.order.dto.request;
 import cholog.wiseshop.db.order.Order;
 import cholog.wiseshop.db.product.Product;
 
-public record CreateOrderRequest(Long productId, int count) {
+public record CreateOrderRequest(Long campaignId, int orderQuantity) {
     public Order from(Product product) {
         return new Order(
                 product,
-                this.count
+                this.orderQuantity
         );
     }
 }

--- a/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
+++ b/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
@@ -32,7 +32,7 @@ public class OrderService {
         }
         Product product = findProducts.get(0);
         Stock stock = product.getStock();
-        if (stock.hasQuantity(request.orderQuantity())) {
+        if (!stock.hasQuantity(request.orderQuantity())) {
             throw new IllegalArgumentException(
                     String.format("주문 가능한 수량을 초과하였습니다. 주문 가능한 수량 : %d개", stock.getTotalQuantity()));
         }

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -45,6 +45,13 @@ public class Campaign {
         this.state = state;
     }
 
+    public void increaseSoldQuantity(int orderQuantity) {
+        soldQuantity -= orderQuantity;
+        if (soldQuantity - orderQuantity == 0) {
+            this.state = CampaignState.SUCCESS;
+        }
+    }
+
     public Long getId() {
         return id;
     }
@@ -63,5 +70,9 @@ public class Campaign {
 
     public CampaignState getState() {
         return state;
+    }
+
+    public boolean isInProgress() {
+        return state.equals(CampaignState.SUCCESS);
     }
 }

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -73,6 +73,6 @@ public class Campaign {
     }
 
     public boolean isInProgress() {
-        return state.equals(CampaignState.SUCCESS);
+        return state.equals(CampaignState.IN_PROGRESS);
     }
 }

--- a/src/main/java/cholog/wiseshop/db/stock/Stock.java
+++ b/src/main/java/cholog/wiseshop/db/stock/Stock.java
@@ -43,10 +43,6 @@ public class Stock {
     }
 
     public boolean hasQuantity(int orderQuantity) {
-        if (totalQuantity < orderQuantity) {
-            throw new IllegalArgumentException(
-                    "주문 가능 수량을 초과하였습니다. 주문 가능한 수량은 " + totalQuantity + "개 입니다.");
-        }
-        return true;
+        return totalQuantity >= orderQuantity;
     }
 }

--- a/src/main/java/cholog/wiseshop/db/stock/Stock.java
+++ b/src/main/java/cholog/wiseshop/db/stock/Stock.java
@@ -14,9 +14,9 @@ public class Stock {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Integer totalQuantity;
+    private int totalQuantity;
 
-    public Stock(Integer totalQuantity) {
+    public Stock(int totalQuantity) {
         this.totalQuantity = totalQuantity;
     }
 
@@ -27,14 +27,26 @@ public class Stock {
         return id;
     }
 
-    public Integer getTotalQuantity() {
+    public int getTotalQuantity() {
         return totalQuantity;
     }
 
-    public void modifyTotalQuantity(Integer modifyQuantity) {
+    public void modifyTotalQuantity(int modifyQuantity) {
         if (modifyQuantity < MINIMUM_QUANTITY) {
             throw new IllegalArgumentException("재고 수량은 최소 1개 이상이어야 합니다.");
         }
         this.totalQuantity = modifyQuantity;
+    }
+
+    public void reduceQuantity(int orderQuantity) {
+        this.totalQuantity -= orderQuantity;
+    }
+
+    public boolean hasQuantity(int orderQuantity) {
+        if (totalQuantity < orderQuantity) {
+            throw new IllegalArgumentException(
+                    "주문 가능 수량을 초과하였습니다. 주문 가능한 수량은 " + totalQuantity + "개 입니다.");
+        }
+        return true;
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/order/OrderServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/order/OrderServiceTest.java
@@ -1,0 +1,78 @@
+package cholog.wiseshop.domain.order;
+
+import static cholog.wiseshop.domain.product.ProductRepositoryTest.getCreateProductRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
+import cholog.wiseshop.api.campaign.service.CampaignService;
+import cholog.wiseshop.api.order.dto.request.CreateOrderRequest;
+import cholog.wiseshop.api.order.dto.response.OrderResponse;
+import cholog.wiseshop.api.order.service.OrderService;
+import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
+import cholog.wiseshop.db.campaign.CampaignRepository;
+import cholog.wiseshop.db.order.OrderRepository;
+import cholog.wiseshop.db.product.ProductRepository;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class OrderServiceTest {
+
+    @Autowired
+    private CampaignService campaignService;
+
+    @Autowired
+    private CampaignRepository campaignRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    private Long campaignId;
+
+    private CreateProductRequest request;
+
+    @BeforeEach
+    void setUp() {
+        request = getCreateProductRequest();
+
+        LocalDateTime startDate = LocalDateTime.now().plus(10, ChronoUnit.MILLIS);
+        LocalDateTime endDate = LocalDateTime.now().plusMinutes(5);
+        int goalQuantity = 5;
+
+        campaignId = campaignService.createCampaign(
+                new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+    }
+
+    @AfterEach
+    void cleanUp() {
+        orderRepository.deleteAll();
+        productRepository.deleteAll();
+        campaignRepository.deleteAll();
+    }
+
+    @Test
+    void 주문_생성_성공() {
+        //given
+        int orderQuantity = 5;
+        CreateOrderRequest orderRequest = new CreateOrderRequest(campaignId, orderQuantity);
+
+        //when
+        Long orderId = orderService.createOrder(orderRequest);
+        OrderResponse response = orderService.readOrder(orderId);
+
+        //then
+        assertThat(response.productName()).isEqualTo(request.name());
+        assertThat(response.count()).isEqualTo(orderQuantity);
+    }
+}


### PR DESCRIPTION
## 요약
- 주문 생성 시, 재고 검증 및 캠페인 검증하도록 `OrderService` 수정
  - **상품 ID가 아닌 캠페인 ID를 입력받도록 수정** 
  - 주문 엔티티가 생성되면, 재고의 총 수량이 감소하고, 캠페인의 판매 수량은 증가
- 주문 생성에 대한 테스트 코드 작성
- 스케줄링 실행할 때, 트랜잭션이 적용되도록 수정

### 스케줄링 실행할 때, 트랜잭션이 적용되도록 수정
[해당 글](https://devsungwon.tistory.com/entry/Spring-TaskScheduler%EB%A1%9C-%EB%8F%99%EC%A0%81-%EC%8A%A4%EC%BC%80%EC%A4%84%EB%A7%81-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0-%EA%B3%A0%EC%A0%95%EB%90%98%EC%A7%80-%EC%95%8A%EC%9D%80-%EC%8B%9C%EA%B0%84)을 참고하여 스케줄링을 실행하는 코드가 트랜잭션 범위 내에서 실행되도록 하였습니다.

![image](https://github.com/user-attachments/assets/4863c454-4942-46d4-b605-b6909a88a30c)
![image](https://github.com/user-attachments/assets/ba77cce3-19c8-4e58-b136-f3a1cce7fb2b)

따라서 이제는 `saveFlush`를 하지 않아도, `UPDATE` 쿼리가 나갑니다.
