### PR TITLE
fix: 전체 테스트 통과하도록 수정

### DIFF
--- a/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
@@ -24,8 +24,8 @@ public class CampaignController {
 
     @PostMapping("/campaigns")
     public ResponseEntity<Long> createCampaigns(@RequestBody CreateCampaignRequest request) {
-        Long productId = campaignService.createCampaign(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(productId);
+        Long campaignId = campaignService.createCampaign(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(campaignId);
     }
 
     @GetMapping("/campaigns/{id}")

--- a/src/main/java/cholog/wiseshop/api/campaign/dto/request/CreateCampaignRequest.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/dto/request/CreateCampaignRequest.java
@@ -6,10 +6,11 @@ import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import java.time.LocalDateTime;
 
 public record CreateCampaignRequest(
-        @JsonSerialize(using = LocalDateTimeSerializer.class)
-        LocalDateTime startDate,
-        @JsonSerialize(using = LocalDateTimeSerializer.class)
-        LocalDateTime endDate,
-        int goalQuantity,
-        CreateProductRequest product) {
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    LocalDateTime startDate,
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    LocalDateTime endDate,
+    int goalQuantity,
+    CreateProductRequest product) {
+
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/dto/response/ReadCampaignResponse.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/dto/response/ReadCampaignResponse.java
@@ -3,8 +3,9 @@ package cholog.wiseshop.api.campaign.dto.response;
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
 
 public record ReadCampaignResponse(Long campaignId,
-                                    String startDate,
-                                    String endDate,
-                                    Integer goalQuantity,
+                                   String startDate,
+                                   String endDate,
+                                   Integer goalQuantity,
                                    ProductResponse product) {
+
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -71,7 +71,8 @@ public class CampaignService {
             new ProductResponse(findProduct));
     }
 
-    public void scheduleCampaignDate(Long campaignId, LocalDateTime startDate, LocalDateTime endDate) {
+    public void scheduleCampaignDate(Long campaignId, LocalDateTime startDate,
+        LocalDateTime endDate) {
         Runnable startCampaign = () -> transactionTemplate.execute(status -> {
             changeCampaingState(campaignId, CampaignState.IN_PROGRESS);
             return null;
@@ -104,7 +105,8 @@ public class CampaignService {
         List<Product> products = productRepository.findAll();
         List<AllCampaignResponse> result = new ArrayList<>();
         for (Product product : products) {
-            AllCampaignResponse allCampaignResponse = AllCampaignResponse.from(product, product.getCampaign());
+            AllCampaignResponse allCampaignResponse = AllCampaignResponse.from(product,
+                product.getCampaign());
             result.add(allCampaignResponse);
         }
         return result;

--- a/src/main/java/cholog/wiseshop/api/order/controller/OrderController.java
+++ b/src/main/java/cholog/wiseshop/api/order/controller/OrderController.java
@@ -38,7 +38,8 @@ public class OrderController {
     }
 
     @PatchMapping("/{id}")
-    public ResponseEntity<Void> modifyOrderCount(@PathVariable Long id, @RequestBody ModifyOrderCountRequest request) {
+    public ResponseEntity<Void> modifyOrderCount(@PathVariable Long id,
+        @RequestBody ModifyOrderCountRequest request) {
         orderService.modifyOrderCount(id, request);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/cholog/wiseshop/api/order/dto/request/CreateOrderRequest.java
+++ b/src/main/java/cholog/wiseshop/api/order/dto/request/CreateOrderRequest.java
@@ -4,10 +4,11 @@ import cholog.wiseshop.db.order.Order;
 import cholog.wiseshop.db.product.Product;
 
 public record CreateOrderRequest(Long campaignId, int orderQuantity) {
+
     public Order from(Product product) {
         return new Order(
-                product,
-                this.orderQuantity
+            product,
+            this.orderQuantity
         );
     }
 }

--- a/src/main/java/cholog/wiseshop/api/order/dto/request/ModifyOrderCountRequest.java
+++ b/src/main/java/cholog/wiseshop/api/order/dto/request/ModifyOrderCountRequest.java
@@ -1,4 +1,5 @@
 package cholog.wiseshop.api.order.dto.request;
 
 public record ModifyOrderCountRequest(int count) {
+
 }

--- a/src/main/java/cholog/wiseshop/api/order/dto/response/OrderResponse.java
+++ b/src/main/java/cholog/wiseshop/api/order/dto/response/OrderResponse.java
@@ -12,12 +12,12 @@ public record OrderResponse(Long id,
 
     public OrderResponse(Order order) {
         this(
-                order.getId(),
-                order.getProduct().getId(),
-                order.getProduct().getName(),
-                order.getCount(),
-                order.getCreatedDate(),
-                order.getModifiedDate()
+            order.getId(),
+            order.getProduct().getId(),
+            order.getProduct().getName(),
+            order.getCount(),
+            order.getCreatedDate(),
+            order.getModifiedDate()
         );
     }
 }

--- a/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
+++ b/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
@@ -26,7 +26,8 @@ public class OrderService {
     }
 
     public Long createOrder(CreateOrderRequest request) {
-        List<Product> findProducts = productRepository.findProductsByCampaignId(request.campaignId());
+        List<Product> findProducts = productRepository.findProductsByCampaignId(
+            request.campaignId());
         if (findProducts.isEmpty()) {
             throw new IllegalArgumentException("상품이 존재하지 않습니다.");
         }
@@ -34,14 +35,14 @@ public class OrderService {
         Stock stock = product.getStock();
         if (!stock.hasQuantity(request.orderQuantity())) {
             throw new IllegalArgumentException(
-                    String.format("주문 가능한 수량을 초과하였습니다. 주문 가능한 수량 : %d개", stock.getTotalQuantity()));
+                String.format("주문 가능한 수량을 초과하였습니다. 주문 가능한 수량 : %d개", stock.getTotalQuantity()));
         }
-        
+
         Campaign campaign = product.getCampaign();
         if (!campaign.isInProgress()) {
             throw new IllegalArgumentException("현재 캠페인이 진행 중이지 않습니다.");
         }
-        
+
         Order order = orderRepository.save(request.from(product));
         stock.reduceQuantity(request.orderQuantity());
         campaign.increaseSoldQuantity(request.orderQuantity());
@@ -51,19 +52,19 @@ public class OrderService {
     @Transactional(readOnly = true)
     public OrderResponse readOrder(Long id) {
         Order order = orderRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("주문 정보가 존재하지 않습니다."));
+            .orElseThrow(() -> new IllegalArgumentException("주문 정보가 존재하지 않습니다."));
         return new OrderResponse(order);
     }
 
     public void modifyOrderCount(Long orderId, ModifyOrderCountRequest request) {
         Order order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalArgumentException("수정할 상품이 존재하지 않습니다."));
+            .orElseThrow(() -> new IllegalArgumentException("수정할 상품이 존재하지 않습니다."));
         order.updateCount(request.count());
     }
 
     public void deleteOrder(Long id) {
         orderRepository.findById(id)
-                        .orElseThrow(() -> new IllegalArgumentException("삭제할 주문이 존재하지 않습니다."));
+            .orElseThrow(() -> new IllegalArgumentException("삭제할 주문이 존재하지 않습니다."));
         orderRepository.deleteById(id);
     }
 }

--- a/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
+++ b/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
@@ -1,6 +1,5 @@
 package cholog.wiseshop.api.product.controller;
 
-import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductPriceRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
@@ -11,7 +10,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,14 +31,14 @@ public class ProductController {
 
     @PatchMapping("/products/{id}")
     public ResponseEntity<Void> modifyProduct(@PathVariable Long id,
-                                              @RequestBody ModifyProductRequest request) {
+        @RequestBody ModifyProductRequest request) {
         productService.modifyProduct(id, request);
         return ResponseEntity.ok().build();
     }
 
     @PatchMapping("/products/{id}/price")
     public ResponseEntity<Void> modifyProductPrice(@PathVariable Long id,
-                                                   @RequestBody ModifyProductPriceRequest request) {
+        @RequestBody ModifyProductPriceRequest request) {
         productService.modifyProductPrice(id, request);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/CreateProductRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/CreateProductRequest.java
@@ -10,10 +10,10 @@ public record CreateProductRequest(String name,
 
     public Product from() {
         return new Product(
-                name,
-                description,
-                price,
-                new Stock(totalQuantity)
+            name,
+            description,
+            price,
+            new Stock(totalQuantity)
         );
     }
 }

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductPriceRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductPriceRequest.java
@@ -1,4 +1,5 @@
 package cholog.wiseshop.api.product.dto.request;
 
 public record ModifyProductPriceRequest(int price) {
+
 }

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductRequest.java
@@ -2,4 +2,5 @@ package cholog.wiseshop.api.product.dto.request;
 
 public record ModifyProductRequest(String name,
                                    String description) {
+
 }

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyQuantityRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyQuantityRequest.java
@@ -3,4 +3,5 @@ package cholog.wiseshop.api.product.dto.request;
 public record ModifyQuantityRequest(Long campaignId,
                                     Long productId,
                                     Integer modifyQuantity) {
+
 }

--- a/src/main/java/cholog/wiseshop/api/product/dto/response/ProductResponse.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/response/ProductResponse.java
@@ -9,10 +9,10 @@ public record ProductResponse(String name,
 
     public ProductResponse(Product product) {
         this(
-                product.getName(),
-                product.getDescription(),
-                product.getPrice(),
-                product.getStock().getTotalQuantity()
+            product.getName(),
+            product.getDescription(),
+            product.getPrice(),
+            product.getStock().getTotalQuantity()
         );
     }
 }

--- a/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
+++ b/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
@@ -26,7 +26,8 @@ public class ProductService {
 
     public Long createProduct(CreateProductRequest request) {
         Stock stock = new Stock(request.totalQuantity());
-        Product product = new Product(request.name(), request.description(), request.price(), stock);
+        Product product = new Product(request.name(), request.description(), request.price(),
+            stock);
         Product createdProduct = productRepository.save(product);
         return createdProduct.getId();
     }
@@ -34,19 +35,19 @@ public class ProductService {
     @Transactional(readOnly = true)
     public ProductResponse getProduct(Long id) {
         return new ProductResponse(productRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("상품 조회에 실패했습니다.")));
+            .orElseThrow(() -> new IllegalArgumentException("상품 조회에 실패했습니다.")));
     }
 
     public void modifyProduct(Long productId, ModifyProductRequest request) {
         Product existedProduct = productRepository.findById(productId)
-                .orElseThrow(() -> new IllegalArgumentException("이름 및 설명글 수정할 상품이 존재하지 않습니다."));
+            .orElseThrow(() -> new IllegalArgumentException("이름 및 설명글 수정할 상품이 존재하지 않습니다."));
         existedProduct.modifyProduct(request.name(), request.description());
         productRepository.save(existedProduct);
     }
 
     public void modifyProductPrice(Long productId, ModifyProductPriceRequest request) {
         Product existedProduct = productRepository.findById(productId)
-                .orElseThrow(() -> new IllegalArgumentException("가격 수정할 상품이 존재하지 않습니다."));
+            .orElseThrow(() -> new IllegalArgumentException("가격 수정할 상품이 존재하지 않습니다."));
         existedProduct.modifyPrice(request.price());
         productRepository.save(existedProduct);
     }
@@ -56,14 +57,14 @@ public class ProductService {
             throw new IllegalArgumentException("캠페인이 시작되어 상품을 수정할 수 없습니다.");
         }
         Product existedProduct = productRepository.findById(request.productId())
-                .orElseThrow(() -> new IllegalArgumentException("상품 조회에 실패했습니다."));
+            .orElseThrow(() -> new IllegalArgumentException("상품 조회에 실패했습니다."));
         Stock existedStock = existedProduct.getStock();
         existedStock.modifyTotalQuantity(request.modifyQuantity());
     }
 
     public void deleteProduct(Long id) {
         productRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("삭제할 상품이 존재하지 않습니다."));
+            .orElseThrow(() -> new IllegalArgumentException("삭제할 상품이 존재하지 않습니다."));
         productRepository.deleteById(id);
     }
 }

--- a/src/main/java/cholog/wiseshop/common/config/JpaConfig.java
+++ b/src/main/java/cholog/wiseshop/common/config/JpaConfig.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @EnableJpaAuditing
 @Configuration
 public class JpaConfig {
+
 }

--- a/src/main/java/cholog/wiseshop/db/campaign/CampaignRepository.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/CampaignRepository.java
@@ -3,4 +3,5 @@ package cholog.wiseshop.db.campaign;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CampaignRepository extends JpaRepository<Campaign, Long> {
+
 }

--- a/src/main/java/cholog/wiseshop/db/order/Order.java
+++ b/src/main/java/cholog/wiseshop/db/order/Order.java
@@ -25,7 +25,8 @@ public class Order extends BaseTimeEntity {
 
     private int count;
 
-    public Order() {}
+    public Order() {
+    }
 
     public Order(Product product, int count) {
         this.product = product;

--- a/src/main/java/cholog/wiseshop/db/order/OrderRepository.java
+++ b/src/main/java/cholog/wiseshop/db/order/OrderRepository.java
@@ -3,4 +3,5 @@ package cholog.wiseshop.db.order;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
+
 }

--- a/src/main/java/cholog/wiseshop/db/stock/StockRepository.java
+++ b/src/main/java/cholog/wiseshop/db/stock/StockRepository.java
@@ -3,4 +3,5 @@ package cholog.wiseshop.db.stock;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StockRepository extends JpaRepository<Stock, Long> {
+
 }

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -72,7 +72,6 @@ public class CampaignServiceTest {
     void 캠페인_조회하기() {
         //given
         CreateProductRequest request = getCreateProductRequest();
-        productService.createProduct(request);
 
         //when
         LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
@@ -97,7 +96,6 @@ public class CampaignServiceTest {
     void 캠페인_조회하기_예외_잘못된_캠페인ID() {
         //given
         CreateProductRequest request = getCreateProductRequest();
-        productService.createProduct(request);
 
         //when
         LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
@@ -117,24 +115,22 @@ public class CampaignServiceTest {
     void 캠페인_시작_상태_변경_성공() {
         //given
         CreateProductRequest request = getCreateProductRequest();
-        productService.createProduct(request);
 
         //when
-        LocalDateTime startDate = LocalDateTime.now().plusSeconds(1);
-        LocalDateTime endDate = LocalDateTime.now().plusSeconds(10);
+        LocalDateTime startDate = LocalDateTime.now().plus(50, ChronoUnit.MILLIS);
+        LocalDateTime endDate = LocalDateTime.now().plusMinutes(10);
         int goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
                 new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
-        Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
 
         // then
         Awaitility.await()
-                .atLeast(900, TimeUnit.MILLISECONDS)
-                .untilAsserted(() -> {
-                    Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
+                .dontCatchUncaughtExceptions()
+                .until(() -> {
+                    Campaign modifiedCampaign = campaignRepository.findById(campaignId)
                             .orElseThrow();
-                    assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.IN_PROGRESS);
+                    return modifiedCampaign.getState().equals(CampaignState.IN_PROGRESS);
                 });
     }
 
@@ -142,11 +138,10 @@ public class CampaignServiceTest {
     void 캠페인_실패_상태_변경_성공() {
         //given
         CreateProductRequest request = getCreateProductRequest();
-        productService.createProduct(request);
 
         //when
         LocalDateTime startDate = LocalDateTime.now();
-        LocalDateTime endDate = LocalDateTime.now().plusSeconds(1);
+        LocalDateTime endDate = LocalDateTime.now().plus(100, ChronoUnit.MILLIS);
         int goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
@@ -155,7 +150,8 @@ public class CampaignServiceTest {
 
         // then
         Awaitility.await()
-                .atLeast(900, TimeUnit.MILLISECONDS)
+                .dontCatchUncaughtExceptions()
+                .atMost(200, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
                     Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
                             .orElseThrow();

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -124,16 +124,16 @@ public class CampaignServiceTest {
         int goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+            new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
 
         // then
         Awaitility.await()
-                .dontCatchUncaughtExceptions()
-                .until(() -> {
-                    Campaign modifiedCampaign = campaignRepository.findById(campaignId)
-                            .orElseThrow();
-                    return modifiedCampaign.getState().equals(CampaignState.IN_PROGRESS);
-                });
+            .dontCatchUncaughtExceptions()
+            .until(() -> {
+                Campaign modifiedCampaign = campaignRepository.findById(campaignId)
+                    .orElseThrow();
+                return modifiedCampaign.getState().equals(CampaignState.IN_PROGRESS);
+            });
     }
 
     @Test
@@ -152,13 +152,13 @@ public class CampaignServiceTest {
 
         // then
         Awaitility.await()
-                .dontCatchUncaughtExceptions()
-                .atMost(200, TimeUnit.MILLISECONDS)
-                .untilAsserted(() -> {
-                    Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
-                            .orElseThrow();
-                    assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.FAILED);
-                });
+            .dontCatchUncaughtExceptions()
+            .atMost(200, TimeUnit.MILLISECONDS)
+            .untilAsserted(() -> {
+                Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
+                    .orElseThrow();
+                assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.FAILED);
+            });
     }
 
     @Test
@@ -187,7 +187,8 @@ public class CampaignServiceTest {
         LocalDateTime startDate = LocalDateTime.now().plusSeconds(1);
         LocalDateTime endDate = LocalDateTime.now().plusSeconds(2);
         int goalQuantity = 5;
-        campaignService.createCampaign(new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+        campaignService.createCampaign(
+            new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
 
         //when
         List<AllCampaignResponse> result = campaignService.readAllCampaign();

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -130,7 +130,7 @@ public class CampaignServiceTest {
 
         // then
         Awaitility.await()
-                .atLeast(1, TimeUnit.SECONDS)
+                .atLeast(900, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
                     Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
                             .orElseThrow();
@@ -155,7 +155,7 @@ public class CampaignServiceTest {
 
         // then
         Awaitility.await()
-                .atLeast(1, TimeUnit.SECONDS)
+                .atLeast(900, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
                     Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
                             .orElseThrow();

--- a/src/test/java/cholog/wiseshop/domain/order/OrderServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/order/OrderServiceTest.java
@@ -54,7 +54,7 @@ public class OrderServiceTest {
         int goalQuantity = 5;
 
         campaignId = campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+            new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
     }
 
     @Test

--- a/src/test/java/cholog/wiseshop/domain/order/OrderServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/order/OrderServiceTest.java
@@ -14,7 +14,6 @@ import cholog.wiseshop.db.order.OrderRepository;
 import cholog.wiseshop.db.product.ProductRepository;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,9 +43,13 @@ public class OrderServiceTest {
 
     @BeforeEach
     void setUp() {
+        orderRepository.deleteAll();
+        productRepository.deleteAll();
+        campaignRepository.deleteAll();
+
         request = getCreateProductRequest();
 
-        LocalDateTime startDate = LocalDateTime.now();
+        LocalDateTime startDate = LocalDateTime.now().plus(50, ChronoUnit.MILLIS);
         LocalDateTime endDate = LocalDateTime.now().plusMinutes(5);
         int goalQuantity = 5;
 
@@ -54,18 +57,13 @@ public class OrderServiceTest {
                 new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
     }
 
-    @AfterEach
-    void cleanUp() {
-        orderRepository.deleteAll();
-        productRepository.deleteAll();
-        campaignRepository.deleteAll();
-    }
-
     @Test
-    void 주문_생성_성공() {
+    void 주문_생성_성공() throws InterruptedException {
         //given
         int orderQuantity = 5;
         CreateOrderRequest orderRequest = new CreateOrderRequest(campaignId, orderQuantity);
+
+        Thread.sleep(100);
 
         //when
         Long orderId = orderService.createOrder(orderRequest);

--- a/src/test/java/cholog/wiseshop/domain/product/ProductRepositoryTest.java
+++ b/src/test/java/cholog/wiseshop/domain/product/ProductRepositoryTest.java
@@ -8,8 +8,6 @@ import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
-import cholog.wiseshop.db.stock.Stock;
-import cholog.wiseshop.db.stock.StockRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,12 +50,13 @@ public class ProductRepositoryTest {
 
         // then
         assertAll(
-                () -> assertThat(products).hasSize(1),
-                () -> assertThat(products.get(0).getName()).isEqualTo(request.name()),
-                () -> assertThat(products.get(0).getDescription()).isEqualTo(request.description()),
-                () -> assertThat(products.get(0).getPrice()).isEqualTo(request.price()),
-                () -> assertThat(products.get(0).getStock().getTotalQuantity()).isEqualTo(request.totalQuantity()),
-                () -> assertThat(products.get(0).getCampaign().getId()).isEqualTo(campaign.getId())
+            () -> assertThat(products).hasSize(1),
+            () -> assertThat(products.get(0).getName()).isEqualTo(request.name()),
+            () -> assertThat(products.get(0).getDescription()).isEqualTo(request.description()),
+            () -> assertThat(products.get(0).getPrice()).isEqualTo(request.price()),
+            () -> assertThat(products.get(0).getStock().getTotalQuantity()).isEqualTo(
+                request.totalQuantity()),
+            () -> assertThat(products.get(0).getCampaign().getId()).isEqualTo(campaign.getId())
         );
     }
 

--- a/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
@@ -13,7 +13,6 @@ import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyQuantityRequest;
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.api.product.service.ProductService;
-import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
 import cholog.wiseshop.db.stock.Stock;
@@ -23,8 +22,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
+@Transactional
 public class ProductServiceTest {
 
     @Autowired
@@ -39,13 +40,9 @@ public class ProductServiceTest {
     @Autowired
     private CampaignService campaignService;
 
-    @Autowired
-    private CampaignRepository campaignRepository;
-
     @BeforeEach
     void cleanUp() {
         productRepository.deleteAll();
-        campaignRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
@@ -84,7 +84,7 @@ public class ProductServiceTest {
 
         // when
         Throwable exception = assertThrows(IllegalArgumentException.class,
-                () -> productService.getProduct(wrongProductId));
+            () -> productService.getProduct(wrongProductId));
 
         // then
         assertThat(exception.getMessage()).isEqualTo("상품 조회에 실패했습니다.");
@@ -102,14 +102,14 @@ public class ProductServiceTest {
         Product createdProduct = productRepository.save(request.from());
 
         ModifyProductRequest modifyProductRequest = new ModifyProductRequest(
-                modifiedName,
-                modifiedDescription
+            modifiedName,
+            modifiedDescription
         );
 
         productService.modifyProduct(createdProduct.getId(), modifyProductRequest);
 
         Product modifiedProduct = productRepository.findById(createdProduct.getId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다."));
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다."));
 
         // then
         assertThat(modifiedProduct.getName()).isEqualTo(modifiedName);
@@ -127,7 +127,7 @@ public class ProductServiceTest {
 
         // when
         Throwable exception = assertThrows(IllegalArgumentException.class,
-                () -> productService.modifyProduct(productId, request));
+            () -> productService.modifyProduct(productId, request));
 
         // then
         assertThat(exception.getMessage()).isEqualTo("이름 및 설명글 수정할 상품이 존재하지 않습니다.");
@@ -143,12 +143,13 @@ public class ProductServiceTest {
         // when
         Product createdProduct = productRepository.save(request.from());
 
-        ModifyProductPriceRequest modifyProductPriceRequest = new ModifyProductPriceRequest(modifiedPrice);
+        ModifyProductPriceRequest modifyProductPriceRequest = new ModifyProductPriceRequest(
+            modifiedPrice);
 
         productService.modifyProductPrice(createdProduct.getId(), modifyProductPriceRequest);
 
         Product modifiedProduct = productRepository.findById(createdProduct.getId())
-                .orElseThrow(() -> new IllegalArgumentException("가격 수정할 상품이 존재하지 않습니다."));
+            .orElseThrow(() -> new IllegalArgumentException("가격 수정할 상품이 존재하지 않습니다."));
 
         // then
         assertThat(modifiedProduct.getPrice()).isEqualTo(modifiedPrice);
@@ -164,7 +165,7 @@ public class ProductServiceTest {
 
         // when
         Throwable exception = assertThrows(IllegalArgumentException.class,
-                () -> productService.modifyProductPrice(productId, request));
+            () -> productService.modifyProductPrice(productId, request));
 
         // then
         assertThat(exception.getMessage()).isEqualTo("가격 수정할 상품이 존재하지 않습니다.");
@@ -181,19 +182,19 @@ public class ProductServiceTest {
         int goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+            new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
         Integer modifyQuantity = 1;
 
         // when
         ModifyQuantityRequest modifyQuantityRequest = new ModifyQuantityRequest(
-                campaignId,
-                productId,
-                modifyQuantity
+            campaignId,
+            productId,
+            modifyQuantity
         );
         productService.modifyStockQuantity(modifyQuantityRequest);
 
         Product modifiedProduct = productRepository.findById(productId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다."));
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다."));
         Stock modifiedStock = modifiedProduct.getStock();
 
         // then
@@ -211,21 +212,21 @@ public class ProductServiceTest {
         int goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+            new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
         Integer modifyQuantity = 0;
 
         // when
         ModifyQuantityRequest modifyQuantityRequest = new ModifyQuantityRequest(
-                campaignId,
-                productId,
-                modifyQuantity
+            campaignId,
+            productId,
+            modifyQuantity
         );
 
         // then
         assertThatThrownBy(() -> productService.modifyStockQuantity(modifyQuantityRequest))
-                .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(IllegalArgumentException.class);
     }
-    
+
     @Test
     void 상품과_재고_삭제하기() {
         // given
@@ -249,7 +250,7 @@ public class ProductServiceTest {
 
         // when
         Throwable exception = assertThrows(IllegalArgumentException.class,
-                () -> productService.deleteProduct(wrongProductId));
+            () -> productService.deleteProduct(wrongProductId));
 
         // then
         assertThat(exception.getMessage()).isEqualTo("삭제할 상품이 존재하지 않습니다.");

--- a/src/test/java/cholog/wiseshop/web/campaign/CampaignControllerTest.java
+++ b/src/test/java/cholog/wiseshop/web/campaign/CampaignControllerTest.java
@@ -12,7 +12,6 @@ import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
 import cholog.wiseshop.api.campaign.service.CampaignService;
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.db.campaign.CampaignRepository;
-import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
@@ -57,8 +56,8 @@ public class CampaignControllerTest {
     @BeforeEach
     public void setUp() {
         mockMvc = MockMvcBuilders
-                .webAppContextSetup(context)
-                .build();
+            .webAppContextSetup(context)
+            .build();
 
         campaignRepository.deleteAll();
         productRepository.deleteAll();
@@ -67,12 +66,12 @@ public class CampaignControllerTest {
     @AfterEach
     public void cleanUp() {
         this.entityManager
-                .createNativeQuery("ALTER TABLE product ALTER COLUMN `id` RESTART WITH 1")
-                .executeUpdate();
+            .createNativeQuery("ALTER TABLE product ALTER COLUMN `id` RESTART WITH 1")
+            .executeUpdate();
 
         this.entityManager
-                .createNativeQuery("ALTER TABLE campaign ALTER COLUMN `id` RESTART WITH 1")
-                .executeUpdate();
+            .createNativeQuery("ALTER TABLE campaign ALTER COLUMN `id` RESTART WITH 1")
+            .executeUpdate();
     }
 
     @Test
@@ -83,18 +82,19 @@ public class CampaignControllerTest {
         Integer goalQuantity = 5;
 
         CreateProductRequest productRequest = getCreateProductRequest();
-        CreateCampaignRequest request = new CreateCampaignRequest(startDate, endDate, goalQuantity, productRequest);
+        CreateCampaignRequest request = new CreateCampaignRequest(startDate, endDate, goalQuantity,
+            productRequest);
 
         String url = "http://localhost:" + port + "/api/v1/campaigns";
 
         // when & then
         mockMvc.perform(post(url)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .characterEncoding("utf-8")
-                        .content(new ObjectMapper().writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(content().string("1"))
-                .andDo(print());
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(new ObjectMapper().writeValueAsString(request)))
+            .andExpect(status().isCreated())
+            .andExpect(content().string("1"))
+            .andDo(print());
     }
 
     @Test
@@ -105,26 +105,27 @@ public class CampaignControllerTest {
         Integer goalQuantity = 5;
 
         CreateProductRequest productRequest = getCreateProductRequest();
-        CreateCampaignRequest request = new CreateCampaignRequest(startDate, endDate, goalQuantity, productRequest);
+        CreateCampaignRequest request = new CreateCampaignRequest(startDate, endDate, goalQuantity,
+            productRequest);
 
         String postUrl = "http://localhost:" + port + "/api/v1/campaigns";
         mockMvc.perform(post(postUrl)
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("utf-8")
                 .content(new ObjectMapper().writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(content().string("1"))
-                .andDo(print());
+            .andExpect(status().isCreated())
+            .andExpect(content().string("1"))
+            .andDo(print());
         String getUrl = "http://localhost:" + port + "/api/v1/campaigns/" + 1;
 
         // when & then
         mockMvc.perform(get(getUrl)
-                        .characterEncoding("utf-8"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.campaignId").value(1))
-                .andExpect(jsonPath("$.startDate").value(startDate.toString()))
-                .andExpect(jsonPath("$.endDate").value(endDate.toString()))
-                .andExpect(jsonPath("$.goalQuantity").value(goalQuantity))
-                .andDo(print());
+                .characterEncoding("utf-8"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.campaignId").value(1))
+            .andExpect(jsonPath("$.startDate").value(startDate.toString()))
+            .andExpect(jsonPath("$.endDate").value(endDate.toString()))
+            .andExpect(jsonPath("$.goalQuantity").value(goalQuantity))
+            .andDo(print());
     }
 }

--- a/src/test/java/cholog/wiseshop/web/product/ProductControllerTest.java
+++ b/src/test/java/cholog/wiseshop/web/product/ProductControllerTest.java
@@ -50,8 +50,8 @@ public class ProductControllerTest {
     @BeforeEach
     public void setUp() {
         mockMvc = MockMvcBuilders
-                .webAppContextSetup(context)
-                .build();
+            .webAppContextSetup(context)
+            .build();
 
         productRepository.deleteAll();
     }
@@ -59,8 +59,8 @@ public class ProductControllerTest {
     @AfterEach
     public void cleanUp() {
         this.entityManager
-                .createNativeQuery("ALTER TABLE product ALTER COLUMN `id` RESTART WITH 1")
-                .executeUpdate();
+            .createNativeQuery("ALTER TABLE product ALTER COLUMN `id` RESTART WITH 1")
+            .executeUpdate();
 
     }
 
@@ -69,10 +69,10 @@ public class ProductControllerTest {
         // given
         CreateProductRequest request = getCreateProductRequest();
         Product product = productRepository.save(new Product(
-                request.name(),
-                request.description(),
-                request.price(),
-                new Stock(request.totalQuantity())
+            request.name(),
+            request.description(),
+            request.price(),
+            new Stock(request.totalQuantity())
         ));
 
         // when
@@ -80,14 +80,14 @@ public class ProductControllerTest {
 
         //then
         mockMvc.perform(get(getUrl)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .characterEncoding("utf-8"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.name").value(request.name()))
-                .andExpect(jsonPath("$.description").value(request.description()))
-                .andExpect(jsonPath("$.price").value(request.price()))
-                .andExpect(jsonPath("$.totalQuantity").value(request.totalQuantity()))
-                .andDo(print());
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.name").value(request.name()))
+            .andExpect(jsonPath("$.description").value(request.description()))
+            .andExpect(jsonPath("$.price").value(request.price()))
+            .andExpect(jsonPath("$.totalQuantity").value(request.totalQuantity()))
+            .andDo(print());
     }
 
     @Test
@@ -106,16 +106,16 @@ public class ProductControllerTest {
         Product savedProduct = productRepository.save(product);
 
         ModifyProductRequest request =
-                new ModifyProductRequest(modifiedName, modifiedDescription);
+            new ModifyProductRequest(modifiedName, modifiedDescription);
 
         String url = "http://localhost:" + port + "/api/v1/products/";
 
         // then
         mockMvc.perform(patch(url + savedProduct.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(new ObjectMapper().writeValueAsString(request))
-                        .characterEncoding("utf-8"))
-                .andExpect(status().isOk());
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(request))
+                .characterEncoding("utf-8"))
+            .andExpect(status().isOk());
     }
 
     @Test
@@ -138,10 +138,10 @@ public class ProductControllerTest {
 
         // then
         mockMvc.perform(patch(url + savedProduct.getId() + "/price")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(new ObjectMapper().writeValueAsString(request))
-                        .characterEncoding("utf-8"))
-                .andExpect(status().isOk());
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(request))
+                .characterEncoding("utf-8"))
+            .andExpect(status().isOk());
     }
 
     @Test
@@ -160,9 +160,9 @@ public class ProductControllerTest {
 
         // then
         mockMvc.perform(delete(url)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .characterEncoding("utf-8"))
-                .andExpect(status().isNoContent())
-                .andDo(print());
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8"))
+            .andExpect(status().isNoContent())
+            .andDo(print());
     }
 }


### PR DESCRIPTION
## 요약
- `OrderServiceTest`에서 주문을 생성하기 전에 밀리세컨드 단위로 `Thread.sleep`을 사용하였습니다.
- 테스트의 격리성을 가져갈 수 있도록 테스트가 시작되기 전에 테스트 데이터를 삭제하도록 일관성을 가져갔습니다. (`@BeforeEach`)