### PR TITLE
refactor: 주문 생성 API 요청 시, productID를 입력받도록 변경

### DIFF
--- a/src/main/java/cholog/wiseshop/api/order/dto/request/CreateOrderRequest.java
+++ b/src/main/java/cholog/wiseshop/api/order/dto/request/CreateOrderRequest.java
@@ -3,7 +3,7 @@ package cholog.wiseshop.api.order.dto.request;
 import cholog.wiseshop.db.order.Order;
 import cholog.wiseshop.db.product.Product;
 
-public record CreateOrderRequest(Long campaignId, int orderQuantity) {
+public record CreateOrderRequest(Long productId, int orderQuantity) {
 
     public Order from(Product product) {
         return new Order(

--- a/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
+++ b/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
@@ -26,12 +26,8 @@ public class OrderService {
     }
 
     public Long createOrder(CreateOrderRequest request) {
-        List<Product> findProducts = productRepository.findProductsByCampaignId(
-            request.campaignId());
-        if (findProducts.isEmpty()) {
-            throw new IllegalArgumentException("상품이 존재하지 않습니다.");
-        }
-        Product product = findProducts.get(0);
+        Product product = productRepository.findById(request.productId())
+            .orElseThrow(() -> new IllegalArgumentException("상품이 존재하지 않습니다."));
         Stock stock = product.getStock();
         if (!stock.hasQuantity(request.orderQuantity())) {
             throw new IllegalArgumentException(

--- a/src/main/java/cholog/wiseshop/db/product/Product.java
+++ b/src/main/java/cholog/wiseshop/db/product/Product.java
@@ -25,7 +25,7 @@ public class Product {
 
     private int price;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "CAMPAIGN_ID")
     private Campaign campaign;
 


### PR DESCRIPTION
## 요약
- `Campaign`이 의존하는 `Product`의 `Fetch Type`을 `LAZY`에서 `EAGER`로 변경
- 주문 생성 API 요청 시, 요청 DTO에 `campaignId`가 아니라 `productId`를 입력받도록 변경
- 주문관련 테스트에 필요한 캠페인 데이터를 **Repository** 객체를 활용하여 수동으로 추가
  - 수동으로 데이터를 추가할 경우, 캠페인 서비스의 `createCampaign` 로직을 호출하지 않기 때문에 `IN_PROGRESS` 상태인 캠페인을 쉽게 생성할 수 있다는 장점이 있습니다. 