### PR TITLE
feat: 주문 목록 조회 API 구현

### DIFF
--- a/src/main/java/cholog/wiseshop/api/order/controller/OrderController.java
+++ b/src/main/java/cholog/wiseshop/api/order/controller/OrderController.java
@@ -4,6 +4,7 @@ import cholog.wiseshop.api.order.dto.request.CreateOrderRequest;
 import cholog.wiseshop.api.order.dto.request.ModifyOrderCountRequest;
 import cholog.wiseshop.api.order.dto.response.OrderResponse;
 import cholog.wiseshop.api.order.service.OrderService;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -25,19 +26,25 @@ public class OrderController {
         this.orderService = orderService;
     }
 
-    @PostMapping
+    @PostMapping("/orders")
     public ResponseEntity<Long> createOrder(@RequestBody CreateOrderRequest request) {
         Long orderId = orderService.createOrder(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(orderId);
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/orders/{id}")
     public ResponseEntity<OrderResponse> readOrder(@PathVariable Long id) {
         OrderResponse response = orderService.readOrder(id);
         return ResponseEntity.ok(response);
     }
 
-    @PatchMapping("/{id}")
+    @GetMapping("/orders")
+    public ResponseEntity<List<OrderResponse>> readMemberOrders() {
+        List<OrderResponse> response = orderService.readOrders();
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/orders/{id}")
     public ResponseEntity<Void> modifyOrderCount(@PathVariable Long id,
         @RequestBody ModifyOrderCountRequest request) {
         orderService.modifyOrderCount(id, request);

--- a/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
+++ b/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
@@ -52,6 +52,11 @@ public class OrderService {
         return new OrderResponse(order);
     }
 
+    @Transactional(readOnly = true)
+    public List<OrderResponse> readOrders() {
+        return orderRepository.findAll().stream().map(OrderResponse::new).toList();
+    }
+
     public void modifyOrderCount(Long orderId, ModifyOrderCountRequest request) {
         Order order = orderRepository.findById(orderId)
             .orElseThrow(() -> new IllegalArgumentException("수정할 상품이 존재하지 않습니다."));

--- a/src/main/java/cholog/wiseshop/db/order/Order.java
+++ b/src/main/java/cholog/wiseshop/db/order/Order.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
@@ -19,8 +20,8 @@ public class Order extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "PRODUCT_ID")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "PRODUCT_ID", unique = false)
     private Product product;
 
     private int count;


### PR DESCRIPTION
### 요약
- 현재 주문한 목록을 볼 수 없어 주문 목록 API를 구현했습니다.
- 테스트 구현 중 1:1 관계에서 외래키를 유니크 속성으로 제한하는 설정이 있어 기존 1:1 관계를 1:N으로 변경했습니다.
  -  해당 부분은 하나의 상품을 여러명이 주문할 수 있다고 생각하여 변경했습니다.
  - 이상하다고 생각하신 부분 있으면 알려주세요!
+ 회원에 대한 내용은 따로 추가하지 않았습니다.