### PR TITLE
refactor: 캠페인 단건/전체 조회 시, 상품 ID도 함께 전달되도록 수정

### DIFF
--- a/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
@@ -1,7 +1,6 @@
 package cholog.wiseshop.api.campaign.controller;
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
-import cholog.wiseshop.api.campaign.dto.response.AllCampaignResponse;
 import cholog.wiseshop.api.campaign.dto.response.ReadCampaignResponse;
 import cholog.wiseshop.api.campaign.service.CampaignService;
 import java.util.List;
@@ -37,8 +36,8 @@ public class CampaignController {
     }
 
     @GetMapping("/campaigns")
-    public ResponseEntity<List<AllCampaignResponse>> readAllCampaign() {
-        List<AllCampaignResponse> response = campaignService.readAllCampaign();
+    public ResponseEntity<List<ReadCampaignResponse>> readAllCampaign() {
+        List<ReadCampaignResponse> response = campaignService.readAllCampaign();
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
@@ -1,6 +1,7 @@
 package cholog.wiseshop.api.campaign.controller;
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
+import cholog.wiseshop.api.campaign.dto.response.AllCampaignResponse;
 import cholog.wiseshop.api.campaign.dto.response.ReadCampaignResponse;
 import cholog.wiseshop.api.campaign.service.CampaignService;
 import java.util.List;
@@ -36,8 +37,8 @@ public class CampaignController {
     }
 
     @GetMapping("/campaigns")
-    public ResponseEntity<List<ReadCampaignResponse>> readAllCampaign() {
+    public ResponseEntity<AllCampaignResponse> readAllCampaign() {
         List<ReadCampaignResponse> response = campaignService.readAllCampaign();
-        return ResponseEntity.status(HttpStatus.OK).body(response);
+        return ResponseEntity.status(HttpStatus.OK).body(new AllCampaignResponse(response));
     }
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/dto/response/AllCampaignResponse.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/dto/response/AllCampaignResponse.java
@@ -3,22 +3,8 @@ package cholog.wiseshop.api.campaign.dto.response;
 import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.product.Product;
 import java.time.LocalDateTime;
+import java.util.List;
 
-public record AllCampaignResponse(Long campaignId,
-                                  String productName,
-                                  String productDescription,
-                                  int goalQuantity,
-                                  LocalDateTime startDate,
-                                  LocalDateTime endDate) {
+public record AllCampaignResponse(List<ReadCampaignResponse> responses) {
 
-    public static AllCampaignResponse from(Product product, Campaign campaign) {
-        return new AllCampaignResponse(
-            campaign.getId(),
-            product.getName(),
-            product.getDescription(),
-            campaign.getGoalQuantity(),
-            campaign.getStartDate(),
-            campaign.getEndDate()
-        );
-    }
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/dto/response/ReadCampaignResponse.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/dto/response/ReadCampaignResponse.java
@@ -1,11 +1,21 @@
 package cholog.wiseshop.api.campaign.dto.response;
 
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
+import cholog.wiseshop.db.campaign.Campaign;
+import cholog.wiseshop.db.product.Product;
 
 public record ReadCampaignResponse(Long campaignId,
                                    String startDate,
                                    String endDate,
-                                   Integer goalQuantity,
+                                   int goalQuantity,
                                    ProductResponse product) {
 
+    public static ReadCampaignResponse of(Product product, Campaign campaign) {
+        return new ReadCampaignResponse(
+            campaign.getId(),
+            campaign.getStartDate().toString(),
+            campaign.getEndDate().toString(),
+            campaign.getGoalQuantity(),
+            new ProductResponse(product));
+    }
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -1,7 +1,6 @@
 package cholog.wiseshop.api.campaign.service;
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
-import cholog.wiseshop.api.campaign.dto.response.AllCampaignResponse;
 import cholog.wiseshop.api.campaign.dto.response.ReadCampaignResponse;
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
@@ -101,14 +100,15 @@ public class CampaignService {
         return false;
     }
 
-    public List<AllCampaignResponse> readAllCampaign() {
+    public List<ReadCampaignResponse> readAllCampaign() {
         List<Product> products = productRepository.findAll();
-        List<AllCampaignResponse> result = new ArrayList<>();
+        List<ReadCampaignResponse> allResponses = new ArrayList<>();
         for (Product product : products) {
-            AllCampaignResponse allCampaignResponse = AllCampaignResponse.from(product,
+            ReadCampaignResponse response = ReadCampaignResponse.of(
+                product,
                 product.getCampaign());
-            result.add(allCampaignResponse);
+            allResponses.add(response);
         }
-        return result;
+        return allResponses;
     }
 }

--- a/src/main/java/cholog/wiseshop/api/product/dto/response/ProductResponse.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/response/ProductResponse.java
@@ -2,13 +2,15 @@ package cholog.wiseshop.api.product.dto.response;
 
 import cholog.wiseshop.db.product.Product;
 
-public record ProductResponse(String name,
+public record ProductResponse(Long id,
+                              String name,
                               String description,
                               Integer price,
                               Integer totalQuantity) {
 
     public ProductResponse(Product product) {
         this(
+            product.getId(),
             product.getName(),
             product.getDescription(),
             product.getPrice(),

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -191,7 +191,7 @@ public class CampaignServiceTest {
             new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
 
         //when
-        List<AllCampaignResponse> result = campaignService.readAllCampaign();
+        List<ReadCampaignResponse> result = campaignService.readAllCampaign();
 
         //then
         Awaitility.await()

--- a/src/test/java/cholog/wiseshop/web/campaign/CampaignControllerTest.java
+++ b/src/test/java/cholog/wiseshop/web/campaign/CampaignControllerTest.java
@@ -156,7 +156,6 @@ public class CampaignControllerTest {
         mockMvc.perform(get(getUrl)
                 .characterEncoding("utf-8"))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.length()").value(2))
             .andDo(print());
     }
 }

--- a/src/test/java/cholog/wiseshop/web/campaign/CampaignControllerTest.java
+++ b/src/test/java/cholog/wiseshop/web/campaign/CampaignControllerTest.java
@@ -98,11 +98,11 @@ public class CampaignControllerTest {
     }
 
     @Test
-    void 캠페인_조회하기() throws Exception {
+    void 캠페인_단건_조회하기() throws Exception {
         // given
         LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
         LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
-        Integer goalQuantity = 5;
+        int goalQuantity = 5;
 
         CreateProductRequest productRequest = getCreateProductRequest();
         CreateCampaignRequest request = new CreateCampaignRequest(startDate, endDate, goalQuantity,
@@ -126,6 +126,37 @@ public class CampaignControllerTest {
             .andExpect(jsonPath("$.startDate").value(startDate.toString()))
             .andExpect(jsonPath("$.endDate").value(endDate.toString()))
             .andExpect(jsonPath("$.goalQuantity").value(goalQuantity))
+            .andDo(print());
+    }
+
+    @Test
+    void 캠페인_전체_조회하기() throws Exception {
+        // given
+        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+        int goalQuantity = 5;
+
+        CreateProductRequest productRequest = getCreateProductRequest();
+        CreateCampaignRequest request = new CreateCampaignRequest(startDate, endDate, goalQuantity,
+            productRequest);
+
+        String postUrl = "http://localhost:" + port + "/api/v1/campaigns";
+        mockMvc.perform(post(postUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(new ObjectMapper().writeValueAsString(request)));
+        mockMvc.perform(post(postUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(new ObjectMapper().writeValueAsString(request)));
+
+        String getUrl = "http://localhost:" + port + "/api/v1/campaigns";
+
+        // when & then
+        mockMvc.perform(get(getUrl)
+                .characterEncoding("utf-8"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.length()").value(2))
             .andDo(print());
     }
 }


### PR DESCRIPTION
## 요약
- 캠페인 단건/전체 조회 시, 연결된 상품의 ID도 같이 반환하도록 컨트롤러 및 서비스의 응답 로직을 수정하였습니다.
- 전체 조회 시, `AllCampaignResponse` 대신 기존에 사용하던 `ReadCampaignResponse`를 사용하도록 변경하였습니다.
  -  `AllCampaignResponse`에서 담고있는 데이터들이 `ReadCampaignResponse`에 모두 존재하기 때문에 이를 `List`에 담아 사용하는 형식으로 변경하였습니다.
  - 이에 따라, 캠페인 단건/전체 API 명세의 응답 부분도 수정하였습니다.

### 캠페인 단건 조회 API 응답
```
{
  "campaignId": 1,
  "startDate": "2025-01-07T10:30",
  "endDate": "2025-01-08T10:30",
  "goalQuantity": 5,
  "product": {
	  "id" : 1,
    "name": "보약",
    "description": "먹으면 기분이 좋아져요.",
    "price": 10000,
    "totalQuantity": 5
  }
}
```

### 캠페인 전체 조회 API 응답
```
{
  "responses": [
    {
      "campaignId": 1,
      "startDate": "2025-01-07T10:30",
      "endDate": "2025-01-08T10:30",
      "goalQuantity": 5,
      "product": {
        "id": 1,
        "name": "보약",
        "description": "먹으면 기분이 좋아져요.",
        "price": 10000,
        "totalQuantity": 5
      }
    },
    {
      "campaignId": 2,
      "startDate": "2025-01-07T10:30",
      "endDate": "2025-01-08T10:30",
      "goalQuantity": 5,
      "product": {
        "id": 2,
        "name": "보약",
        "description": "먹으면 기분이 좋아져요.",
        "price": 10000,
        "totalQuantity": 5
      }
    }
  ]
}
```