### PR TITLE
feature: Swagger를 도입했습니다!

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.security:spring-security-crypto:6.4.2'
     implementation 'org.slf4j:slf4j-api:2.0.16'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.security:spring-security-crypto:6.4.2'
     implementation 'org.slf4j:slf4j-api:2.0.16'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/cholog/wiseshop/common/config/SwaggerConfig.java
+++ b/src/main/java/cholog/wiseshop/common/config/SwaggerConfig.java
@@ -1,0 +1,5 @@
+package cholog.wiseshop.common.config;
+
+
+public class SwaggerConfig {
+}

--- a/src/main/java/cholog/wiseshop/common/config/SwaggerConfig.java
+++ b/src/main/java/cholog/wiseshop/common/config/SwaggerConfig.java
@@ -1,5 +1,19 @@
 package cholog.wiseshop.common.config;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
+@Configuration
 public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("wiseshop API")
+                        .version("v1.0")
+                        .description("wiseshop API"));
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,18 @@ spring:
       hibernate:
         show_sql: true
         format_sql:
+
+springdoc:
+  packages-to-scan: cholog
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    path: /swagger-ui
+    tags-sorter: alpha
+    operations-sorter: alpha
+  api-docs:
+    path: /api/swagger-docs
+    groups:
+      enabled: true
+  cache:
+    disabled: true


### PR DESCRIPTION
### 요약
- 2.3.2 버전을 사용하려 했으나 `ControllerAdviceBean` 클래스이 존재하지 않는 문제가 발생하여 2.8.3 버전으로 올려 사용을 진행했습니다.
- `SwaggerConfig` 클래스 구현
- `.yml`에 `swagger`에 적용할 기본 정보 작성