### PR TITLE
refactor: 주문 및 캠페인 API에 회원 검증에 대한 리팩터링

### DIFF
--- a/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
@@ -4,6 +4,8 @@ import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
 import cholog.wiseshop.api.campaign.dto.response.AllCampaignResponse;
 import cholog.wiseshop.api.campaign.dto.response.ReadCampaignResponse;
 import cholog.wiseshop.api.campaign.service.CampaignService;
+import cholog.wiseshop.common.auth.Auth;
+import cholog.wiseshop.db.member.Member;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,8 +27,8 @@ public class CampaignController {
     }
 
     @PostMapping("/campaigns")
-    public ResponseEntity<Long> createCampaigns(@RequestBody CreateCampaignRequest request) {
-        Long campaignId = campaignService.createCampaign(request);
+    public ResponseEntity<Long> createCampaigns(@Auth Member member, @RequestBody CreateCampaignRequest request) {
+        Long campaignId = campaignService.createCampaign(request, member);
         return ResponseEntity.status(HttpStatus.CREATED).body(campaignId);
     }
 

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -7,6 +7,7 @@ import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.campaign.CampaignState;
+import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
 import cholog.wiseshop.db.stock.Stock;
@@ -43,13 +44,13 @@ public class CampaignService {
         this.transactionTemplate = new TransactionTemplate(transactionManager);
     }
 
-    public Long createCampaign(CreateCampaignRequest request) {
+    public Long createCampaign(CreateCampaignRequest request, Member member) {
         CreateProductRequest productRequest = request.product();
         Stock stock = stockRepository.save(new Stock(productRequest.totalQuantity()));
         Product product = productRepository.save(new Product(
             productRequest.name(), productRequest.description(), productRequest.price(), stock));
         Campaign campaign = campaignRepository.save(
-            new Campaign(request.startDate(), request.endDate(), request.goalQuantity()));
+            new Campaign(request.startDate(), request.endDate(), request.goalQuantity(), member));
         product.addCampaign(campaign);
         scheduleCampaignDate(campaign.getId(), request.startDate(), request.endDate());
         return campaign.getId();

--- a/src/main/java/cholog/wiseshop/api/order/controller/OrderController.java
+++ b/src/main/java/cholog/wiseshop/api/order/controller/OrderController.java
@@ -4,6 +4,8 @@ import cholog.wiseshop.api.order.dto.request.CreateOrderRequest;
 import cholog.wiseshop.api.order.dto.request.ModifyOrderCountRequest;
 import cholog.wiseshop.api.order.dto.response.OrderResponse;
 import cholog.wiseshop.api.order.service.OrderService;
+import cholog.wiseshop.common.auth.Auth;
+import cholog.wiseshop.db.member.Member;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,8 +29,8 @@ public class OrderController {
     }
 
     @PostMapping("/orders")
-    public ResponseEntity<Long> createOrder(@RequestBody CreateOrderRequest request) {
-        Long orderId = orderService.createOrder(request);
+    public ResponseEntity<Long> createOrder(@Auth Member member, @RequestBody CreateOrderRequest request) {
+        Long orderId = orderService.createOrder(request, member);
         return ResponseEntity.status(HttpStatus.CREATED).body(orderId);
     }
 

--- a/src/main/java/cholog/wiseshop/api/order/controller/OrderController.java
+++ b/src/main/java/cholog/wiseshop/api/order/controller/OrderController.java
@@ -41,8 +41,8 @@ public class OrderController {
     }
 
     @GetMapping("/orders")
-    public ResponseEntity<List<OrderResponse>> readMemberOrders() {
-        List<OrderResponse> response = orderService.readOrders();
+    public ResponseEntity<List<OrderResponse>> readMemberOrders(@Auth Member member) {
+        List<OrderResponse> response = orderService.readMemberOrders(member);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/cholog/wiseshop/api/order/dto/request/CreateOrderRequest.java
+++ b/src/main/java/cholog/wiseshop/api/order/dto/request/CreateOrderRequest.java
@@ -1,14 +1,16 @@
 package cholog.wiseshop.api.order.dto.request;
 
+import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.order.Order;
 import cholog.wiseshop.db.product.Product;
 
 public record CreateOrderRequest(Long productId, int orderQuantity) {
 
-    public Order from(Product product) {
+    public Order from(Product product, Member member) {
         return new Order(
             product,
-            this.orderQuantity
+            this.orderQuantity,
+            member
         );
     }
 }

--- a/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
+++ b/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
@@ -14,6 +14,7 @@ import cholog.wiseshop.exception.WiseShopErrorCode;
 import cholog.wiseshop.exception.WiseShopException;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,8 +63,8 @@ public class OrderService {
     }
 
     @Transactional(readOnly = true)
-    public List<OrderResponse> readOrders() {
-        return orderRepository.findAll().stream().map(OrderResponse::new).toList();
+    public List<OrderResponse> readMemberOrders(Member member) {
+        return orderRepository.findByMemberId(member.getId()).stream().map(OrderResponse::new).toList();
     }
 
     public void modifyOrderCount(Long orderId, ModifyOrderCountRequest request) {

--- a/src/main/java/cholog/wiseshop/common/auth/AuthArgumentResolver.java
+++ b/src/main/java/cholog/wiseshop/common/auth/AuthArgumentResolver.java
@@ -2,6 +2,8 @@ package cholog.wiseshop.common.auth;
 
 import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.member.MemberRepository;
+import cholog.wiseshop.exception.WiseShopErrorCode;
+import cholog.wiseshop.exception.WiseShopException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.core.MethodParameter;
@@ -31,9 +33,9 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
         HttpSession session = webRequest.getNativeRequest(HttpServletRequest.class).getSession();
         Member member = (Member) session.getAttribute(SESSION_KEY);
         if (member == null) {
-            throw new IllegalArgumentException("올바르지 않은 세션 정보입니다.");
+            throw new WiseShopException(WiseShopErrorCode.MEMBER_SESSION_NOT_EXIST);
         }
         return memberRepository.findById(member.getId())
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+            .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.MEMBER_ID_NOT_FOUND));
     }
 }

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 
@@ -35,7 +36,7 @@ public class Campaign {
 
     private CampaignState state;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "MEMBER_ID")
     private Member member;
 

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -1,13 +1,17 @@
 package cholog.wiseshop.db.campaign;
 
+import cholog.wiseshop.db.member.Member;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 
 @Entity
@@ -31,7 +35,24 @@ public class Campaign {
 
     private CampaignState state;
 
-    public Campaign(LocalDateTime startDate, LocalDateTime endDate, int goalQuantity) {
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MEMBER_ID")
+    private Member member;
+
+    public Campaign(LocalDateTime startDate,
+                    LocalDateTime endDate,
+                    int goalQuantity,
+                    Member member) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.goalQuantity = goalQuantity;
+        this.state = CampaignState.WAITING;
+        this.member = member;
+    }
+
+    public Campaign(LocalDateTime startDate,
+                    LocalDateTime endDate,
+                    int goalQuantity) {
         this.startDate = startDate;
         this.endDate = endDate;
         this.goalQuantity = goalQuantity;
@@ -70,6 +91,10 @@ public class Campaign {
 
     public CampaignState getState() {
         return state;
+    }
+
+    public Member getMember() {
+        return member;
     }
 
     public boolean isInProgress() {

--- a/src/main/java/cholog/wiseshop/db/member/Member.java
+++ b/src/main/java/cholog/wiseshop/db/member/Member.java
@@ -28,7 +28,19 @@ public class Member {
     @Column(name = "password", nullable = false)
     private String password;
 
-    public Member(String email, String name, String password) {
+    public Member(Long id,
+                  String email,
+                  String name,
+                  String password) {
+        this.id = id;
+        this.email = email;
+        this.name = name;
+        this.password = password;
+    }
+
+    public Member(String email,
+                  String name,
+                  String password) {
         this.email = email;
         this.name = name;
         this.password = password;

--- a/src/main/java/cholog/wiseshop/db/order/Order.java
+++ b/src/main/java/cholog/wiseshop/db/order/Order.java
@@ -1,6 +1,7 @@
 package cholog.wiseshop.db.order;
 
 import cholog.wiseshop.db.BaseTimeEntity;
+import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.product.Product;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -24,14 +25,19 @@ public class Order extends BaseTimeEntity {
     @JoinColumn(name = "PRODUCT_ID", unique = false)
     private Product product;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MEMBER_ID")
+    private Member member;
+
     private int count;
 
     public Order() {
     }
 
-    public Order(Product product, int count) {
+    public Order(Product product, int count, Member member) {
         this.product = product;
         this.count = count;
+        this.member = member;
     }
 
     public void updateCount(int count) {

--- a/src/main/java/cholog/wiseshop/db/order/OrderRepository.java
+++ b/src/main/java/cholog/wiseshop/db/order/OrderRepository.java
@@ -1,7 +1,9 @@
 package cholog.wiseshop.db.order;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
+    List<Order> findByMemberId(Long memberId);
 }

--- a/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
+++ b/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
@@ -12,7 +12,8 @@ public enum WiseShopErrorCode {
     CAMPAIGN_NOT_IN_PROGRESS("현재 캠페인이 진행 중이지 않습니다."),
     CAMPAIGN_ALREADY_IN_PROGRESS("캠페인이 이미 진행 중 입니다."),
     STOCK_NOT_AVAILABLE("재고 수량은 최소 1개 이상이어야 합니다."),
-    ORDER_NOT_FOUND("주문 정보가 존재하지 않습니다.")
+    ORDER_NOT_FOUND("주문 정보가 존재하지 않습니다."),
+    ORDER_NOT_AVAILABLE("자신이 만든 캠페인은 주문이 불가능합니다.")
     ;
 
     private String message;

--- a/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
+++ b/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
@@ -4,6 +4,7 @@ public enum WiseShopErrorCode {
 
     ALREADY_EXIST_MEMBER("이미 존재하는 회원입니다."),
     MEMBER_ID_NOT_FOUND("올바르지 않은 아이디 입니다."),
+    MEMBER_SESSION_NOT_EXIST("올바르지 않은 접근입니다."),
     PRODUCT_NOT_FOUND("상품이 존재하지 않습니다."),
     MODIFY_NAME_DESCRIPTION_PRODUCT_NOT_FOUND("이름 및 설명글 수정할 상품이 존재하지 않습니다."),
     MODIFY_PRICE_PRODUCT_NOT_FOUND("가격 수정할 상품이 존재하지 않습니다."),

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -57,7 +57,7 @@ public class CampaignServiceTest {
         Integer goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
-            new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
         Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
 
         //then
@@ -81,7 +81,7 @@ public class CampaignServiceTest {
         int goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
-            new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
         ReadCampaignResponse response = campaignService.readCampaign(campaignId);
 
         //then
@@ -105,7 +105,7 @@ public class CampaignServiceTest {
         int goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
-            new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
         Long wrongId = campaignId + 1;
 
         //then
@@ -124,7 +124,7 @@ public class CampaignServiceTest {
         int goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
-            new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
 
         // then
         Awaitility.await()
@@ -147,7 +147,7 @@ public class CampaignServiceTest {
         int goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
-            new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
         Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
 
         // then
@@ -173,7 +173,7 @@ public class CampaignServiceTest {
         int goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
-            new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
         // then
         Awaitility.await()
             .atLeast(1, TimeUnit.SECONDS)
@@ -188,7 +188,7 @@ public class CampaignServiceTest {
         LocalDateTime endDate = LocalDateTime.now().plusSeconds(2);
         int goalQuantity = 5;
         campaignService.createCampaign(
-            new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
 
         //when
         List<ReadCampaignResponse> result = campaignService.readAllCampaign();

--- a/src/test/java/cholog/wiseshop/domain/order/OrderServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/order/OrderServiceTest.java
@@ -67,7 +67,7 @@ public class OrderServiceTest {
         campaign.updateState(CampaignState.IN_PROGRESS);
 
         //when
-        Long orderId = orderService.createOrder(orderRequest);
+        Long orderId = orderService.createOrder(orderRequest, member.getId());
         OrderResponse response = orderService.readOrder(orderId);
 
         //then
@@ -84,9 +84,9 @@ public class OrderServiceTest {
         campaign.updateState(CampaignState.IN_PROGRESS);
 
         //when
-        orderService.createOrder(orderRequest);
-        orderService.createOrder(orderRequest);
-        orderService.createOrder(orderRequest);
+        orderService.createOrder(orderRequest, member.getId());
+        orderService.createOrder(orderRequest, member.getId());
+        orderService.createOrder(orderRequest, member.getId());
         List<OrderResponse> response = orderService.readOrders();
 
         //then

--- a/src/test/java/cholog/wiseshop/domain/order/OrderServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/order/OrderServiceTest.java
@@ -2,6 +2,7 @@ package cholog.wiseshop.domain.order;
 
 import static cholog.wiseshop.domain.product.ProductRepositoryTest.getCreateProductRequest;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import cholog.wiseshop.api.order.dto.request.CreateOrderRequest;
 import cholog.wiseshop.api.order.dto.response.OrderResponse;
@@ -17,6 +18,8 @@ import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
 import cholog.wiseshop.db.stock.Stock;
 import cholog.wiseshop.db.stock.StockRepository;
+import cholog.wiseshop.exception.WiseShopErrorCode;
+import cholog.wiseshop.exception.WiseShopException;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,6 +86,20 @@ public class OrderServiceTest {
         //then
         assertThat(response.productName()).isEqualTo(productRequest.name());
         assertThat(response.count()).isEqualTo(orderQuantity);
+    }
+
+    @Test
+    void 본인이_생성한_상품_주문_예외() {
+        //given
+        int orderQuantity = 5;
+        Long productId = product.getId();
+        CreateOrderRequest orderRequest = new CreateOrderRequest(productId, orderQuantity);
+        campaign.updateState(CampaignState.IN_PROGRESS);
+
+        //when
+        assertThatThrownBy(() -> orderService.createOrder(orderRequest, member))
+                .isInstanceOf(WiseShopException.class)
+                .hasMessage(WiseShopErrorCode.ORDER_NOT_AVAILABLE.getMessage());
     }
 
     @Test

--- a/src/test/java/cholog/wiseshop/domain/order/OrderServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/order/OrderServiceTest.java
@@ -10,12 +10,15 @@ import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.campaign.CampaignState;
+import cholog.wiseshop.db.member.Member;
+import cholog.wiseshop.db.member.MemberRepository;
 import cholog.wiseshop.db.order.OrderRepository;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
 import cholog.wiseshop.db.stock.Stock;
 import cholog.wiseshop.db.stock.StockRepository;
 import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,11 +42,16 @@ public class OrderServiceTest {
     private OrderRepository orderRepository;
 
     @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
     private OrderService orderService;
 
     private Campaign campaign;
 
     private Product product;
+
+    private Member member;
 
     private CreateProductRequest productRequest;
 
@@ -54,7 +62,8 @@ public class OrderServiceTest {
         Stock stock = stockRepository.save(new Stock(productRequest.totalQuantity()));
         product = productRepository.save(new Product(
             productRequest.name(), productRequest.description(), productRequest.price(), stock));
-        campaign = campaignRepository.save(new Campaign(null, null, 5));
+        member = memberRepository.save(new Member("test@naver.com", "초록", "qwer"));
+        campaign = campaignRepository.save(new Campaign(null, null, 5, member));
         product.addCampaign(campaign);
     }
 
@@ -65,9 +74,10 @@ public class OrderServiceTest {
         Long productId = product.getId();
         CreateOrderRequest orderRequest = new CreateOrderRequest(productId, orderQuantity);
         campaign.updateState(CampaignState.IN_PROGRESS);
+        Member orderMember = memberRepository.save(new Member("test2@naver.com", "초록2", "qwer2"));
 
         //when
-        Long orderId = orderService.createOrder(orderRequest, member.getId());
+        Long orderId = orderService.createOrder(orderRequest, orderMember);
         OrderResponse response = orderService.readOrder(orderId);
 
         //then
@@ -81,15 +91,14 @@ public class OrderServiceTest {
         int orderQuantity = 1;
         Long productId = product.getId();
         CreateOrderRequest orderRequest = new CreateOrderRequest(productId, orderQuantity);
+        Member orderMember = memberRepository.save(new Member("test2@naver.com", "초록2", "qwer2"));
         campaign.updateState(CampaignState.IN_PROGRESS);
 
         //when
-        orderService.createOrder(orderRequest, member.getId());
-        orderService.createOrder(orderRequest, member.getId());
-        orderService.createOrder(orderRequest, member.getId());
-        List<OrderResponse> response = orderService.readOrders();
+        orderService.createOrder(orderRequest, orderMember);
+        List<OrderResponse> response = orderService.readMemberOrders(orderMember);
 
         //then
-        assertThat(response.size()).isEqualTo(3L);
+        assertThat(response.size()).isEqualTo(1L);
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
@@ -176,7 +176,7 @@ public class ProductServiceTest {
         int goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
-            new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
         Integer modifyQuantity = 1;
 
         // when
@@ -206,7 +206,7 @@ public class ProductServiceTest {
         int goalQuantity = 5;
 
         Long campaignId = campaignService.createCampaign(
-            new CreateCampaignRequest(startDate, endDate, goalQuantity, request));
+            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
         Integer modifyQuantity = 0;
 
         // when

--- a/src/test/java/cholog/wiseshop/web/campaign/CampaignControllerTest.java
+++ b/src/test/java/cholog/wiseshop/web/campaign/CampaignControllerTest.java
@@ -12,6 +12,8 @@ import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
 import cholog.wiseshop.api.campaign.service.CampaignService;
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.db.campaign.CampaignRepository;
+import cholog.wiseshop.db.member.Member;
+import cholog.wiseshop.db.member.MemberRepository;
 import cholog.wiseshop.db.product.ProductRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
@@ -24,6 +26,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,6 +36,8 @@ import org.springframework.web.context.WebApplicationContext;
 @Transactional
 public class CampaignControllerTest {
 
+    private static final String SESSION_KEY = "member";
+
     @Autowired
     private WebApplicationContext context;
 
@@ -41,6 +46,9 @@ public class CampaignControllerTest {
 
     @Autowired
     private CampaignRepository campaignRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
 
     @Autowired
     private CampaignService campaignService;
@@ -53,11 +61,18 @@ public class CampaignControllerTest {
 
     private MockMvc mockMvc;
 
+    private MockHttpSession mockHttpSession;
+
+    private Member mockMember;
+
     @BeforeEach
     public void setUp() {
         mockMvc = MockMvcBuilders
             .webAppContextSetup(context)
             .build();
+        mockMember = memberRepository.save(new Member("test@naver.com", "초록", "qwer"));
+        mockHttpSession = new MockHttpSession();
+        mockHttpSession.setAttribute(SESSION_KEY, mockMember);
 
         campaignRepository.deleteAll();
         productRepository.deleteAll();
@@ -91,7 +106,8 @@ public class CampaignControllerTest {
         mockMvc.perform(post(url)
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("utf-8")
-                .content(new ObjectMapper().writeValueAsString(request)))
+                .content(new ObjectMapper().writeValueAsString(request))
+                .session(mockHttpSession))
             .andExpect(status().isCreated())
             .andExpect(content().string("1"))
             .andDo(print());
@@ -112,7 +128,8 @@ public class CampaignControllerTest {
         mockMvc.perform(post(postUrl)
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("utf-8")
-                .content(new ObjectMapper().writeValueAsString(request)))
+                .content(new ObjectMapper().writeValueAsString(request))
+                .session(mockHttpSession))
             .andExpect(status().isCreated())
             .andExpect(content().string("1"))
             .andDo(print());


### PR DESCRIPTION
### 요약
- 주문 생성 및 목록 조회 로직에 회원 검증을 추가
- 테스트를 통한 회원 검증 정상 동작 확인

### 변경사항
- Campaign Entity, Order Entity에 Member를 N:1 매핑 관계 추가
- 매핑 관계 추가에 따른 테스트 코드 수정
- 회원 검증 추가로 발생한 테스트 코드 수정

### 정책
- 자신이 만든 캠페인은 스스로 주문할 수 없다.
- 자신이 주문한 목록만 조회 가능하다.