### PR TITLE
refactor: 회원 주문의 관게를 1:N으로 변경

### DIFF
--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -26,92 +26,105 @@ import org.springframework.transaction.support.TransactionTemplate;
 @Transactional
 public class CampaignService {
 
-    private final CampaignRepository campaignRepository;
-    private final ProductRepository productRepository;
-    private final StockRepository stockRepository;
-    private final ThreadPoolTaskScheduler scheduler;
-    private final TransactionTemplate transactionTemplate;
+	private final CampaignRepository campaignRepository;
+	private final ProductRepository productRepository;
+	private final StockRepository stockRepository;
+	private final ThreadPoolTaskScheduler scheduler;
+	private final TransactionTemplate transactionTemplate;
 
-    public CampaignService(CampaignRepository campaignRepository,
-                           ProductRepository productRepository,
-                           StockRepository stockRepository,
-                           ThreadPoolTaskScheduler scheduler,
-                           PlatformTransactionManager transactionManager) {
-        this.campaignRepository = campaignRepository;
-        this.productRepository = productRepository;
-        this.stockRepository = stockRepository;
-        this.scheduler = scheduler;
-        this.transactionTemplate = new TransactionTemplate(transactionManager);
-    }
+	public CampaignService(CampaignRepository campaignRepository,
+		ProductRepository productRepository,
+		StockRepository stockRepository,
+		ThreadPoolTaskScheduler scheduler,
+		PlatformTransactionManager transactionManager
+	) {
+		this.campaignRepository = campaignRepository;
+		this.productRepository = productRepository;
+		this.stockRepository = stockRepository;
+		this.scheduler = scheduler;
+		this.transactionTemplate = new TransactionTemplate(transactionManager);
+	}
 
-    public Long createCampaign(CreateCampaignRequest request, Member member) {
-        CreateProductRequest productRequest = request.product();
-        Stock stock = stockRepository.save(new Stock(productRequest.totalQuantity()));
-        Product product = productRepository.save(
-                new Product(productRequest.name(), productRequest.description(), productRequest.price(), stock));
-        Campaign campaign = campaignRepository.save(
-            new Campaign(request.startDate(), request.endDate(), request.goalQuantity(), member));
-        product.addCampaign(campaign);
-        scheduleCampaignDate(campaign.getId(), request.startDate(), request.endDate());
-        return campaign.getId();
-    }
+	public Long createCampaign(CreateCampaignRequest request, Member member) {
+		CreateProductRequest productRequest = request.product();
+		Stock stock = stockRepository.save(new Stock(productRequest.totalQuantity()));
+		Product product = productRepository.save(
+			new Product(
+				productRequest.name(),
+				productRequest.description(),
+				productRequest.price(),
+				stock
+			)
+		);
+		Campaign campaign = campaignRepository.save(
+			new Campaign(
+				request.startDate(),
+				request.endDate(),
+				request.goalQuantity(),
+				member
+			)
+		);
+		product.addCampaign(campaign);
+		scheduleCampaignDate(campaign.getId(), request.startDate(), request.endDate());
+		return campaign.getId();
+	}
 
-    @Transactional(readOnly = true)
-    public ReadCampaignResponse readCampaign(Long campaignId) {
-        List<Product> findProducts = productRepository.findProductsByCampaignId(campaignId);
-        if (findProducts.isEmpty()) {
-            throw new IllegalArgumentException("캠페인이 존재하지 않습니다.");
-        }
-        Product findProduct = findProducts.get(0);
-        Campaign findCampaign = findProduct.getCampaign();
-        return new ReadCampaignResponse(
-            campaignId,
-            findCampaign.getStartDate().toString(),
-            findCampaign.getEndDate().toString(), findCampaign.getGoalQuantity(),
-            new ProductResponse(findProduct)
-        );
-    }
+	@Transactional(readOnly = true)
+	public ReadCampaignResponse readCampaign(Long campaignId) {
+		List<Product> findProducts = productRepository.findProductsByCampaignId(campaignId);
+		if (findProducts.isEmpty()) {
+			throw new IllegalArgumentException("캠페인이 존재하지 않습니다.");
+		}
+		Product findProduct = findProducts.get(0);
+		Campaign findCampaign = findProduct.getCampaign();
+		return new ReadCampaignResponse(
+			campaignId,
+			findCampaign.getStartDate().toString(),
+			findCampaign.getEndDate().toString(), findCampaign.getGoalQuantity(),
+			new ProductResponse(findProduct)
+		);
+	}
 
-    public void scheduleCampaignDate(Long campaignId,
-                                     LocalDateTime startDate,
-                                     LocalDateTime endDate) {
-        Runnable startCampaign = () -> transactionTemplate.execute(status -> {
-            changeCampaingState(campaignId, CampaignState.IN_PROGRESS);
-            return null;
-        });
-        scheduler.schedule(startCampaign, startDate.atZone(ZoneId.systemDefault()).toInstant());
+	public void scheduleCampaignDate(Long campaignId,
+		LocalDateTime startDate,
+		LocalDateTime endDate) {
+		Runnable startCampaign = () -> transactionTemplate.execute(status -> {
+			changeCampaingState(campaignId, CampaignState.IN_PROGRESS);
+			return null;
+		});
+		scheduler.schedule(startCampaign, startDate.atZone(ZoneId.systemDefault()).toInstant());
 
-        Runnable endCampaign = () -> transactionTemplate.execute(status -> {
-            changeCampaingState(campaignId, CampaignState.FAILED);
-            return null;
-        });
-        scheduler.schedule(endCampaign, endDate.atZone(ZoneId.systemDefault()).toInstant());
-    }
+		Runnable endCampaign = () -> transactionTemplate.execute(status -> {
+			changeCampaingState(campaignId, CampaignState.FAILED);
+			return null;
+		});
+		scheduler.schedule(endCampaign, endDate.atZone(ZoneId.systemDefault()).toInstant());
+	}
 
-    public void changeCampaingState(Long campaignId, CampaignState state) {
-        Campaign campaign = campaignRepository.findById(campaignId)
-            .orElseThrow(() -> new IllegalArgumentException("상태 변경할 캠페인 정보가 존재하지 않습니다."));
-        campaign.updateState(state);
-    }
+	public void changeCampaingState(Long campaignId, CampaignState state) {
+		Campaign campaign = campaignRepository.findById(campaignId)
+			.orElseThrow(() -> new IllegalArgumentException("상태 변경할 캠페인 정보가 존재하지 않습니다."));
+		campaign.updateState(state);
+	}
 
-    public boolean isStarted(Long campaignId) {
-        Campaign campaign = campaignRepository.findById(campaignId)
-            .orElseThrow(() -> new IllegalArgumentException("캠페인이 존재하지 않습니다."));
-        if (campaign.getState().equals(CampaignState.IN_PROGRESS)) {
-            return true;
-        }
-        return false;
-    }
+	public boolean isStarted(Long campaignId) {
+		Campaign campaign = campaignRepository.findById(campaignId)
+			.orElseThrow(() -> new IllegalArgumentException("캠페인이 존재하지 않습니다."));
+		if (campaign.getState().equals(CampaignState.IN_PROGRESS)) {
+			return true;
+		}
+		return false;
+	}
 
-    public List<ReadCampaignResponse> readAllCampaign() {
-        List<Product> products = productRepository.findAll();
-        List<ReadCampaignResponse> allResponses = new ArrayList<>();
-        for (Product product : products) {
-            ReadCampaignResponse response = ReadCampaignResponse.of(
-                product,
-                product.getCampaign());
-            allResponses.add(response);
-        }
-        return allResponses;
-    }
+	public List<ReadCampaignResponse> readAllCampaign() {
+		List<Product> products = productRepository.findAll();
+		List<ReadCampaignResponse> allResponses = new ArrayList<>();
+		for (Product product : products) {
+			ReadCampaignResponse response = ReadCampaignResponse.of(
+				product,
+				product.getCampaign());
+			allResponses.add(response);
+		}
+		return allResponses;
+	}
 }

--- a/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
+++ b/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
@@ -21,70 +21,70 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class OrderService {
 
-	private final OrderRepository orderRepository;
-	private final ProductRepository productRepository;
+    private final OrderRepository orderRepository;
+    private final ProductRepository productRepository;
 
-	public OrderService(OrderRepository orderRepository, ProductRepository productRepository) {
-		this.orderRepository = orderRepository;
-		this.productRepository = productRepository;
-	}
+    public OrderService(OrderRepository orderRepository, ProductRepository productRepository) {
+        this.orderRepository = orderRepository;
+        this.productRepository = productRepository;
+    }
 
-	public Long createOrder(CreateOrderRequest request, Member member) {
-		Product product = productRepository.findById(request.productId())
-			.orElseThrow(() -> new WiseShopException(WiseShopErrorCode.PRODUCT_NOT_FOUND));
-		Campaign campaign = product.getCampaign();
-		validateCampaignState(campaign);
-		Stock stock = product.getStock();
-		validateQuantity(campaign, stock, request.orderQuantity());
-		Member campaignOwner = campaign.getMember();
-		validateOrderOwner(campaignOwner, member);
-		Order order = orderRepository.save(request.from(product, member));
-		campaign.increaseSoldQuantity(request.orderQuantity());
-		return order.getId();
-	}
+    public Long createOrder(CreateOrderRequest request, Member member) {
+        Product product = productRepository.findById(request.productId())
+            .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.PRODUCT_NOT_FOUND));
+        Campaign campaign = product.getCampaign();
+        validateCampaignState(campaign);
+        Stock stock = product.getStock();
+        validateQuantity(campaign, stock, request.orderQuantity());
+        Member campaignOwner = campaign.getMember();
+        validateOrderOwner(campaignOwner, member);
+        Order order = orderRepository.save(request.from(product, member));
+        campaign.increaseSoldQuantity(request.orderQuantity());
+        return order.getId();
+    }
 
-	@Transactional(readOnly = true)
-	public OrderResponse readOrder(Long id) {
-		Order order = orderRepository.findById(id)
-			.orElseThrow(() -> new WiseShopException(WiseShopErrorCode.ORDER_NOT_FOUND));
-		return new OrderResponse(order);
-	}
+    @Transactional(readOnly = true)
+    public OrderResponse readOrder(Long id) {
+        Order order = orderRepository.findById(id)
+            .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.ORDER_NOT_FOUND));
+        return new OrderResponse(order);
+    }
 
-	@Transactional(readOnly = true)
-	public List<OrderResponse> readMemberOrders(Member member) {
-		return orderRepository.findByMemberId(member.getId())
-			.stream().map(OrderResponse::new).toList();
-	}
+    @Transactional(readOnly = true)
+    public List<OrderResponse> readMemberOrders(Member member) {
+        return orderRepository.findByMemberId(member.getId())
+            .stream().map(OrderResponse::new).toList();
+    }
 
-	public void modifyOrderCount(Long orderId, ModifyOrderCountRequest request) {
-		Order order = orderRepository.findById(orderId)
-			.orElseThrow(() -> new WiseShopException(WiseShopErrorCode.ORDER_NOT_FOUND));
-		order.updateCount(request.count());
-	}
+    public void modifyOrderCount(Long orderId, ModifyOrderCountRequest request) {
+        Order order = orderRepository.findById(orderId)
+            .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.ORDER_NOT_FOUND));
+        order.updateCount(request.count());
+    }
 
-	public void deleteOrder(Long id) {
-		orderRepository.findById(id)
-			.orElseThrow(() -> new WiseShopException(WiseShopErrorCode.ORDER_NOT_FOUND));
-		orderRepository.deleteById(id);
-	}
+    public void deleteOrder(Long id) {
+        orderRepository.findById(id)
+            .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.ORDER_NOT_FOUND));
+        orderRepository.deleteById(id);
+    }
 
-	public void validateQuantity(Campaign campaign, Stock stock, int orderQuantity) {
-		int remainQuantity = stock.getTotalQuantity() - campaign.getSoldQuantity();
+    public void validateQuantity(Campaign campaign, Stock stock, int orderQuantity) {
+        int remainQuantity = stock.getTotalQuantity() - campaign.getSoldQuantity();
 
-		if (remainQuantity - orderQuantity < 0) {
-			throw new WiseShopException(WiseShopErrorCode.ORDER_LIMIT_EXCEED, remainQuantity);
-		}
-	}
+        if (remainQuantity - orderQuantity < 0) {
+            throw new WiseShopException(WiseShopErrorCode.ORDER_LIMIT_EXCEED, remainQuantity);
+        }
+    }
 
-	public void validateCampaignState(Campaign campaign) {
-		if (!campaign.isInProgress()) {
-			throw new WiseShopException(WiseShopErrorCode.CAMPAIGN_NOT_IN_PROGRESS);
-		}
-	}
+    public void validateCampaignState(Campaign campaign) {
+        if (!campaign.isInProgress()) {
+            throw new WiseShopException(WiseShopErrorCode.CAMPAIGN_NOT_IN_PROGRESS);
+        }
+    }
 
-	public void validateOrderOwner(Member campaignOwner, Member orderMember) {
-		if (Objects.equals(campaignOwner.getId(), orderMember.getId())) {
-			throw new WiseShopException(WiseShopErrorCode.ORDER_NOT_AVAILABLE);
-		}
-	}
+    public void validateOrderOwner(Member campaignOwner, Member orderMember) {
+        if (Objects.equals(campaignOwner.getId(), orderMember.getId())) {
+            throw new WiseShopException(WiseShopErrorCode.ORDER_NOT_AVAILABLE);
+        }
+    }
 }

--- a/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
+++ b/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
@@ -37,7 +37,7 @@ public class OrderService {
 		Stock stock = product.getStock();
 		validateQuantity(campaign, stock, request.orderQuantity());
 		Member campaignOwner = campaign.getMember();
-		validateOrderOwner(campaign, campaignOwner);
+		validateOrderOwner(campaignOwner, member);
 		Order order = orderRepository.save(request.from(product, member));
 		campaign.increaseSoldQuantity(request.orderQuantity());
 		return order.getId();
@@ -82,8 +82,8 @@ public class OrderService {
 		}
 	}
 
-	public void validateOrderOwner(Campaign campaign, Member campaignOwner) {
-		if (Objects.equals(campaign.getId(), campaignOwner.getId())) {
+	public void validateOrderOwner(Member campaignOwner, Member orderMember) {
+		if (Objects.equals(campaignOwner.getId(), orderMember.getId())) {
 			throw new WiseShopException(WiseShopErrorCode.ORDER_NOT_AVAILABLE);
 		}
 	}

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -73,7 +73,7 @@ public class Campaign {
 
     public void increaseSoldQuantity(int orderQuantity) {
         soldQuantity += orderQuantity;
-        if (orderQuantity - soldQuantity == 0) {
+        if (goalQuantity - soldQuantity == 0) {
             this.state = CampaignState.SUCCESS;
         }
     }

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -73,7 +73,7 @@ public class Campaign {
 
     public void increaseSoldQuantity(int orderQuantity) {
         soldQuantity += orderQuantity;
-        if (soldQuantity - orderQuantity == 0) {
+        if (orderQuantity - soldQuantity == 0) {
             this.state = CampaignState.SUCCESS;
         }
     }
@@ -92,6 +92,10 @@ public class Campaign {
 
     public int getGoalQuantity() {
         return goalQuantity;
+    }
+
+    public int getSoldQuantity() {
+        return soldQuantity;
     }
 
     public CampaignState getState() {

--- a/src/main/java/cholog/wiseshop/db/order/Order.java
+++ b/src/main/java/cholog/wiseshop/db/order/Order.java
@@ -25,7 +25,7 @@ public class Order extends BaseTimeEntity {
     @JoinColumn(name = "PRODUCT_ID", unique = false)
     private Product product;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "MEMBER_ID")
     private Member member;
 

--- a/src/main/java/cholog/wiseshop/db/stock/Stock.java
+++ b/src/main/java/cholog/wiseshop/db/stock/Stock.java
@@ -41,12 +41,4 @@ public class Stock {
         }
         this.totalQuantity = modifyQuantity;
     }
-
-    public void reduceQuantity(int orderQuantity) {
-        this.totalQuantity -= orderQuantity;
-    }
-
-    public boolean hasQuantity(int orderQuantity) {
-        return totalQuantity >= orderQuantity;
-    }
 }


### PR DESCRIPTION
### 요약
- 회원, 주문의 관계가 1:1로 매핑되어 있어 유니크 제약 조건에 의해 주문을 여러개 생성하지 못하는 문제가 존재 
- 따라서 기존 1:1 관계를 회원, 주문 1:N 관계로 변경
- 총 재고량이 줄어드는 현상을 방지하기 위해 해당 로직 삭제
- 이에 따라 남아있는 재고를 총 재고량 - 판매량으로 변경
- 기존 검증 로직이 주문 생성 하나의 메서드에 많이 포함되어 이를 별도의 메소드로 분리함
