### PR TITLE
feat: 결제승인 API 요청하는 로직 구현

### DIFF
--- a/src/main/java/cholog/wiseshop/api/payment/controller/PaymentClient.java
+++ b/src/main/java/cholog/wiseshop/api/payment/controller/PaymentClient.java
@@ -1,0 +1,48 @@
+package cholog.wiseshop.api.payment.controller;
+
+import cholog.wiseshop.api.payment.dto.PaymentRequest;
+import cholog.wiseshop.api.payment.dto.PaymentResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class PaymentClient {
+
+    private static final String TOSS_PAYMENTS_API_URL = "https://api.tosspayments.com/v1/payments";
+
+    @Value("${toss.payments.secret-key}")
+    private String secretKey;
+
+    private final RestClient restClient;
+
+    public PaymentClient() {
+        this.restClient = RestClient.builder()
+            .baseUrl(TOSS_PAYMENTS_API_URL)
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+            .build();
+    }
+
+    @RequestMapping(value = "/confirm")
+    public ResponseEntity<PaymentResponse> confirmPayment(@RequestBody PaymentRequest request) {
+        Base64.Encoder encoder = Base64.getEncoder();
+        byte[] encodedBytes = encoder.encode((secretKey + ":")
+            .getBytes(StandardCharsets.UTF_8));
+        String authorizations = "Basic " + new String(encodedBytes);
+
+        return restClient.post()
+            .uri(TOSS_PAYMENTS_API_URL + "/confirm")
+            .header(HttpHeaders.AUTHORIZATION, authorizations)
+            .body(request)
+            .retrieve()
+            .toEntity(PaymentResponse.class);
+    }
+}

--- a/src/main/java/cholog/wiseshop/api/payment/dto/PaymentRequest.java
+++ b/src/main/java/cholog/wiseshop/api/payment/dto/PaymentRequest.java
@@ -1,0 +1,7 @@
+package cholog.wiseshop.api.payment.dto;
+
+public record PaymentRequest(String orderId,
+                             Long amount,
+                             String paymentKey) {
+
+}

--- a/src/main/java/cholog/wiseshop/api/payment/dto/PaymentResponse.java
+++ b/src/main/java/cholog/wiseshop/api/payment/dto/PaymentResponse.java
@@ -1,0 +1,5 @@
+package cholog.wiseshop.api.payment.dto;
+
+public record PaymentResponse() {
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -18,3 +18,6 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+toss:
+  payments:
+    secret-key: ${TOSS_SECRET_KEY}


### PR DESCRIPTION
## 작업 내용
- Toss PG사에 결제 승인 API 요청하는 로직을 RestClient로 구현
- 시크릿 키를 환경변수로 지정
 - 로컬환경에서 인텔리제이 실행 시, 환경변수 주입해서 실행

![image](https://github.com/user-attachments/assets/d45b0ac6-6b9e-42e1-852f-c8d4c6f0756b)
- 해당 부분에서 **프론트 서버**에게 전달받은 **결제정보**로 **결제승인 API**를 요청하는 부분

### 의문점
- 주문과 결제를 하나의 트랜잭션으로 묶기로 했기 때문에 지금처럼 **결제승인 API**를 열어두는게 아니라 `OrderService`** 쪽에서 `confirmPayment` 메서드를 호출하는 방향으로 바꿔야 하는걸까요?