### PR TITLE
refactor: 캠페인 로직 수정

### DIFF
--- a/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
@@ -2,6 +2,7 @@ package cholog.wiseshop.api.campaign.controller;
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
 import cholog.wiseshop.api.campaign.dto.response.AllCampaignResponse;
+import cholog.wiseshop.api.campaign.dto.response.CreateCampaignResponse;
 import cholog.wiseshop.api.campaign.dto.response.ReadCampaignResponse;
 import cholog.wiseshop.api.campaign.service.CampaignService;
 import cholog.wiseshop.common.auth.Auth;
@@ -27,9 +28,9 @@ public class CampaignController {
     }
 
     @PostMapping("/campaigns")
-    public ResponseEntity<Long> createCampaigns(@Auth Member member, @RequestBody CreateCampaignRequest request) {
-        Long campaignId = campaignService.createCampaign(request, member);
-        return ResponseEntity.status(HttpStatus.CREATED).body(campaignId);
+    public ResponseEntity<CreateCampaignResponse> createCampaigns(@Auth Member member, @RequestBody CreateCampaignRequest request) {
+        CreateCampaignResponse response = campaignService.createCampaign(request, member);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @GetMapping("/campaigns/{id}")

--- a/src/main/java/cholog/wiseshop/api/campaign/dto/request/CreateCampaignRequest.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/dto/request/CreateCampaignRequest.java
@@ -11,6 +11,6 @@ public record CreateCampaignRequest(
         @JsonSerialize(using = LocalDateTimeSerializer.class)
         LocalDateTime endDate,
         int goalQuantity,
-        CreateProductRequest product) {
+        CreateProductRequest productRequest) {
 
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/dto/response/CreateCampaignResponse.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/dto/response/CreateCampaignResponse.java
@@ -1,0 +1,10 @@
+package cholog.wiseshop.api.campaign.dto.response;
+
+public record CreateCampaignResponse(
+    Long campaignId
+) {
+
+    public static CreateCampaignResponse from(Long campaignId) {
+        return new CreateCampaignResponse(campaignId);
+    }
+}

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -1,68 +1,75 @@
 package cholog.wiseshop.api.campaign.service;
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
+import cholog.wiseshop.api.campaign.dto.response.CreateCampaignResponse;
 import cholog.wiseshop.api.campaign.dto.response.ReadCampaignResponse;
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
+import cholog.wiseshop.common.ThreadTaskScheduler;
 import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.campaign.CampaignRepository;
-import cholog.wiseshop.db.campaign.CampaignState;
 import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
 import cholog.wiseshop.db.stock.Stock;
 import cholog.wiseshop.db.stock.StockRepository;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import cholog.wiseshop.exception.WiseShopErrorCode;
+import cholog.wiseshop.exception.WiseShopException;
 import java.util.ArrayList;
 import java.util.List;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class CampaignService {
 
     private final CampaignRepository campaignRepository;
     private final ProductRepository productRepository;
     private final StockRepository stockRepository;
-    private final ThreadPoolTaskScheduler scheduler;
-    private final TransactionTemplate transactionTemplate;
+    private final ThreadTaskScheduler scheduler;
 
     public CampaignService(CampaignRepository campaignRepository,
-                           ProductRepository productRepository,
-                           StockRepository stockRepository,
-                           ThreadPoolTaskScheduler scheduler,
-                           PlatformTransactionManager transactionManager) {
+        ProductRepository productRepository,
+        StockRepository stockRepository, ThreadTaskScheduler scheduler) {
         this.campaignRepository = campaignRepository;
         this.productRepository = productRepository;
         this.stockRepository = stockRepository;
         this.scheduler = scheduler;
-        this.transactionTemplate = new TransactionTemplate(transactionManager);
     }
 
-    public Long createCampaign(CreateCampaignRequest request, Member member) {
-        CreateProductRequest productRequest = request.product();
-        Stock stock = stockRepository.save(new Stock(productRequest.totalQuantity()));
-        Product product = productRepository.save(
-                new Product(productRequest.name(), productRequest.description(), productRequest.price(), stock));
-        Campaign campaign = campaignRepository.save(
-            new Campaign(request.startDate(), request.endDate(), request.goalQuantity(), member));
-        product.addCampaign(campaign);
-        scheduleCampaignDate(campaign.getId(), request.startDate(), request.endDate());
-        return campaign.getId();
+    @Transactional
+    public CreateCampaignResponse createCampaign(CreateCampaignRequest request, Member member) {
+        Campaign campaign = saveStockAndCampaignAndProduct(request, member);
+        scheduler.scheduleCampaignByDate(campaign);
+        return CreateCampaignResponse.from(campaign.getId());
     }
 
-    @Transactional(readOnly = true)
+    private Campaign saveStockAndCampaignAndProduct(CreateCampaignRequest campaignRequest, Member member) {
+        CreateProductRequest productAtCampaignRequest = campaignRequest.product();
+        Stock stock = stockRepository.save(new Stock(productAtCampaignRequest.totalQuantity()));
+        Campaign campaign = campaignRepository.save(new Campaign(
+            campaignRequest.startDate(),
+            campaignRequest.endDate(),
+            campaignRequest.goalQuantity(),
+            member
+        ));
+        productRepository.save(new Product(
+            productAtCampaignRequest.name(),
+            productAtCampaignRequest.description(),
+            productAtCampaignRequest.price(),
+            campaign,
+            stock
+        ));
+        return campaign;
+    }
+
     public ReadCampaignResponse readCampaign(Long campaignId) {
         List<Product> findProducts = productRepository.findProductsByCampaignId(campaignId);
         if (findProducts.isEmpty()) {
-            throw new IllegalArgumentException("캠페인이 존재하지 않습니다.");
+            throw new WiseShopException(WiseShopErrorCode.CAMPAIGN_NOT_FOUND);
         }
-        Product findProduct = findProducts.get(0);
+        Product findProduct = findProducts.getFirst();
         Campaign findCampaign = findProduct.getCampaign();
         return new ReadCampaignResponse(
             campaignId,
@@ -71,37 +78,15 @@ public class CampaignService {
             new ProductResponse(findProduct)
         );
     }
-
-    public void scheduleCampaignDate(Long campaignId,
-                                     LocalDateTime startDate,
-                                     LocalDateTime endDate) {
-        Runnable startCampaign = () -> transactionTemplate.execute(status -> {
-            changeCampaingState(campaignId, CampaignState.IN_PROGRESS);
-            return null;
-        });
-        scheduler.schedule(startCampaign, startDate.atZone(ZoneId.systemDefault()).toInstant());
-
-        Runnable endCampaign = () -> transactionTemplate.execute(status -> {
-            changeCampaingState(campaignId, CampaignState.FAILED);
-            return null;
-        });
-        scheduler.schedule(endCampaign, endDate.atZone(ZoneId.systemDefault()).toInstant());
-    }
-
-    public void changeCampaingState(Long campaignId, CampaignState state) {
-        Campaign campaign = campaignRepository.findById(campaignId)
-            .orElseThrow(() -> new IllegalArgumentException("상태 변경할 캠페인 정보가 존재하지 않습니다."));
-        campaign.updateState(state);
-    }
-
-    public boolean isStarted(Long campaignId) {
-        Campaign campaign = campaignRepository.findById(campaignId)
-            .orElseThrow(() -> new IllegalArgumentException("캠페인이 존재하지 않습니다."));
-        if (campaign.getState().equals(CampaignState.IN_PROGRESS)) {
-            return true;
-        }
-        return false;
-    }
+//
+//    public boolean isStarted(Long campaignId) {
+//        Campaign campaign = campaignRepository.findById(campaignId)
+//            .orElseThrow(() -> new IllegalArgumentException("캠페인이 존재하지 않습니다."));
+//        if (campaign.getState().equals(CampaignState.IN_PROGRESS)) {
+//            return true;
+//        }
+//        return false;
+//    }
 
     public List<ReadCampaignResponse> readAllCampaign() {
         List<Product> products = productRepository.findAll();

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -15,7 +15,6 @@ import cholog.wiseshop.db.stock.Stock;
 import cholog.wiseshop.db.stock.StockRepository;
 import cholog.wiseshop.exception.WiseShopErrorCode;
 import cholog.wiseshop.exception.WiseShopException;
-import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -78,25 +77,11 @@ public class CampaignService {
             new ProductResponse(findProduct)
         );
     }
-//
-//    public boolean isStarted(Long campaignId) {
-//        Campaign campaign = campaignRepository.findById(campaignId)
-//            .orElseThrow(() -> new IllegalArgumentException("캠페인이 존재하지 않습니다."));
-//        if (campaign.getState().equals(CampaignState.IN_PROGRESS)) {
-//            return true;
-//        }
-//        return false;
-//    }
 
     public List<ReadCampaignResponse> readAllCampaign() {
         List<Product> products = productRepository.findAll();
-        List<ReadCampaignResponse> allResponses = new ArrayList<>();
-        for (Product product : products) {
-            ReadCampaignResponse response = ReadCampaignResponse.of(
-                product,
-                product.getCampaign());
-            allResponses.add(response);
-        }
-        return allResponses;
+        return products.stream()
+            .map(product -> ReadCampaignResponse.of(product, product.getCampaign()))
+            .toList();
     }
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -54,7 +54,7 @@ public class CampaignService {
             campaign,
             stock
         ));
-        scheduler.scheduleCampaignByDate(campaign);
+        scheduler.scheduleCampaign(campaign);
         return CreateCampaignResponse.from(campaign.getId());
     }
 

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -38,14 +38,8 @@ public class CampaignService {
     }
 
     @Transactional
-    public CreateCampaignResponse createCampaign(CreateCampaignRequest request, Member member) {
-        Campaign campaign = saveStockAndCampaignAndProduct(request, member);
-        scheduler.scheduleCampaignByDate(campaign);
-        return CreateCampaignResponse.from(campaign.getId());
-    }
-
-    private Campaign saveStockAndCampaignAndProduct(CreateCampaignRequest campaignRequest, Member member) {
-        CreateProductRequest productAtCampaignRequest = campaignRequest.product();
+    public CreateCampaignResponse createCampaign(CreateCampaignRequest campaignRequest, Member member) {
+        CreateProductRequest productAtCampaignRequest = campaignRequest.productRequest();
         Stock stock = stockRepository.save(new Stock(productAtCampaignRequest.totalQuantity()));
         Campaign campaign = campaignRepository.save(new Campaign(
             campaignRequest.startDate(),
@@ -60,7 +54,8 @@ public class CampaignService {
             campaign,
             stock
         ));
-        return campaign;
+        scheduler.scheduleCampaignByDate(campaign);
+        return CreateCampaignResponse.from(campaign.getId());
     }
 
     public ReadCampaignResponse readCampaign(Long campaignId) {

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/CreateProductRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/CreateProductRequest.java
@@ -8,7 +8,7 @@ public record CreateProductRequest(
     String description,
     int price,
     int totalQuantity
-    ) {
+) {
 
     public Product from() {
         return new Product(

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/CreateProductRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/CreateProductRequest.java
@@ -3,10 +3,12 @@ package cholog.wiseshop.api.product.dto.request;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.stock.Stock;
 
-public record CreateProductRequest(String name,
-                                   String description,
-                                   int price,
-                                   int totalQuantity) {
+public record CreateProductRequest(
+    String name,
+    String description,
+    int price,
+    int totalQuantity
+    ) {
 
     public Product from() {
         return new Product(

--- a/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
+++ b/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
@@ -1,10 +1,8 @@
 package cholog.wiseshop.api.product.service;
 
-import cholog.wiseshop.api.campaign.service.CampaignService;
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductPriceRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
-import cholog.wiseshop.api.product.dto.request.ModifyQuantityRequest;
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
@@ -19,11 +17,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProductService {
 
     private final ProductRepository productRepository;
-    private final CampaignService campaignService;
 
-    public ProductService(ProductRepository productRepository, CampaignService campaignService) {
+    public ProductService(ProductRepository productRepository) {
         this.productRepository = productRepository;
-        this.campaignService = campaignService;
     }
 
     public Long createProduct(CreateProductRequest request) {
@@ -51,17 +47,6 @@ public class ProductService {
             .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.MODIFY_PRICE_PRODUCT_NOT_FOUND));
         existedProduct.modifyPrice(request.price());
         productRepository.save(existedProduct);
-    }
-
-    //테스트 제외 사용되지 않는 메서드
-    public void modifyStockQuantity(ModifyQuantityRequest request) {
-        if (campaignService.isStarted(request.campaignId())) {
-            throw new WiseShopException(WiseShopErrorCode.CAMPAIGN_ALREADY_IN_PROGRESS);
-        }
-        Product existedProduct = productRepository.findById(request.productId())
-            .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.PRODUCT_NOT_FOUND));
-        Stock existedStock = existedProduct.getStock();
-        existedStock.modifyTotalQuantity(request.modifyQuantity());
     }
 
     public void deleteProduct(Long id) {

--- a/src/main/java/cholog/wiseshop/common/ThreadTaskScheduler.java
+++ b/src/main/java/cholog/wiseshop/common/ThreadTaskScheduler.java
@@ -18,15 +18,17 @@ public class ThreadTaskScheduler {
     private final TransactionTemplate transactionTemplate;
     private final CampaignRepository campaignRepository;
 
-    public ThreadTaskScheduler(ThreadPoolTaskScheduler scheduler,
+    public ThreadTaskScheduler(
+        ThreadPoolTaskScheduler scheduler,
         PlatformTransactionManager transactionManager,
-        CampaignRepository campaignRepository) {
+        CampaignRepository campaignRepository
+    ) {
         this.scheduler = scheduler;
         this.transactionTemplate = new TransactionTemplate(transactionManager);
         this.campaignRepository = campaignRepository;
     }
 
-    public void scheduleCampaignByDate(Campaign campaign) {
+    public void scheduleCampaign(Campaign campaign) {
         Runnable startCampaign = () -> transactionTemplate.execute(status -> {
             changeCampaignState(campaign.getId(), CampaignState.IN_PROGRESS);
             return null;

--- a/src/main/java/cholog/wiseshop/common/ThreadTaskScheduler.java
+++ b/src/main/java/cholog/wiseshop/common/ThreadTaskScheduler.java
@@ -1,0 +1,48 @@
+package cholog.wiseshop.common;
+
+import cholog.wiseshop.db.campaign.Campaign;
+import cholog.wiseshop.db.campaign.CampaignRepository;
+import cholog.wiseshop.db.campaign.CampaignState;
+import cholog.wiseshop.exception.WiseShopErrorCode;
+import cholog.wiseshop.exception.WiseShopException;
+import java.time.ZoneId;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Component
+public class ThreadTaskScheduler {
+
+    private final ThreadPoolTaskScheduler scheduler;
+    private final TransactionTemplate transactionTemplate;
+    private final CampaignRepository campaignRepository;
+
+    public ThreadTaskScheduler(ThreadPoolTaskScheduler scheduler,
+        PlatformTransactionManager transactionManager,
+        CampaignRepository campaignRepository) {
+        this.scheduler = scheduler;
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
+        this.campaignRepository = campaignRepository;
+    }
+
+    public void scheduleCampaignByDate(Campaign campaign) {
+        Runnable startCampaign = () -> transactionTemplate.execute(status -> {
+            changeCampaignState(campaign.getId(), CampaignState.IN_PROGRESS);
+            return null;
+        });
+        scheduler.schedule(startCampaign, campaign.getStartDate().atZone(ZoneId.systemDefault()).toInstant());
+
+        Runnable endCampaign = () -> transactionTemplate.execute(status -> {
+            changeCampaignState(campaign.getId(), CampaignState.FAILED);
+            return null;
+        });
+        scheduler.schedule(endCampaign, campaign.getEndDate().atZone(ZoneId.systemDefault()).toInstant());
+    }
+
+    private void changeCampaignState(Long campaignId, CampaignState state) {
+        Campaign campaign = campaignRepository.findById(campaignId)
+            .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.CAMPAIGN_NOT_FOUND));
+        campaign.updateState(state);
+    }
+}

--- a/src/main/java/cholog/wiseshop/common/config/TimeZoneConfig.java
+++ b/src/main/java/cholog/wiseshop/common/config/TimeZoneConfig.java
@@ -1,0 +1,14 @@
+package cholog.wiseshop.common.config;
+
+import jakarta.annotation.PostConstruct;
+import java.util.TimeZone;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeZoneConfig {
+
+    @PostConstruct
+    public void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+}

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -78,10 +78,6 @@ public class Campaign {
         }
     }
 
-    public boolean isStarted() {
-        return getState().equals(CampaignState.IN_PROGRESS);
-    }
-
     public Long getId() {
         return id;
     }
@@ -107,6 +103,6 @@ public class Campaign {
     }
 
     public boolean isInProgress() {
-        return state.equals(CampaignState.IN_PROGRESS);
+        return CampaignState.IN_PROGRESS.equals(state);
     }
 }

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -45,9 +45,9 @@ public class Campaign {
     private Member member;
 
     public Campaign(LocalDateTime startDate,
-                    LocalDateTime endDate,
-                    int goalQuantity,
-                    Member member) {
+        LocalDateTime endDate,
+        int goalQuantity,
+        Member member) {
         this.startDate = startDate;
         this.endDate = endDate;
         this.goalQuantity = goalQuantity;
@@ -56,8 +56,8 @@ public class Campaign {
     }
 
     public Campaign(LocalDateTime startDate,
-                    LocalDateTime endDate,
-                    int goalQuantity) {
+        LocalDateTime endDate,
+        int goalQuantity) {
         this.startDate = startDate;
         this.endDate = endDate;
         this.goalQuantity = goalQuantity;
@@ -76,6 +76,10 @@ public class Campaign {
         if (soldQuantity - orderQuantity == 0) {
             this.state = CampaignState.SUCCESS;
         }
+    }
+
+    public boolean isStarted() {
+        return getState().equals(CampaignState.IN_PROGRESS);
     }
 
     public Long getId() {

--- a/src/main/java/cholog/wiseshop/db/product/Product.java
+++ b/src/main/java/cholog/wiseshop/db/product/Product.java
@@ -53,6 +53,14 @@ public class Product {
         this.price = price;
     }
 
+    public Product(String name, String description, int price, Campaign campaign, Stock stock) {
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.campaign = campaign;
+        this.stock = stock;
+    }
+
     public Product() {
 
     }

--- a/src/main/java/cholog/wiseshop/db/product/Product.java
+++ b/src/main/java/cholog/wiseshop/db/product/Product.java
@@ -2,7 +2,6 @@ package cholog.wiseshop.db.product;
 
 import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.stock.Stock;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -31,23 +30,21 @@ public class Product {
     @JoinColumn(name = "CAMPAIGN_ID")
     private Campaign campaign;
 
-    @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "STOCK_ID")
     private Stock stock;
 
     public Product(String name,
-                   String description,
-                   Integer price,
-                   Stock stock) {
+        String description,
+        Integer price,
+        Stock stock) {
         this.name = name;
         this.description = description;
         this.price = price;
         this.stock = stock;
     }
 
-    public Product(String name,
-                   String description,
-                   int price) {
+    public Product(String name, String description, int price) {
         this.name = name;
         this.description = description;
         this.price = price;

--- a/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
+++ b/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
@@ -9,6 +9,7 @@ public enum WiseShopErrorCode {
     MODIFY_NAME_DESCRIPTION_PRODUCT_NOT_FOUND("이름 및 설명글 수정할 상품이 존재하지 않습니다."),
     MODIFY_PRICE_PRODUCT_NOT_FOUND("가격 수정할 상품이 존재하지 않습니다."),
     ORDER_LIMIT_EXCEED("주문 가능한 수량을 초과하였습니다. 주문 가능한 수량 : %d개"),
+    CAMPAIGN_NOT_FOUND("존재하지 않는 캠페인 입니다."),
     CAMPAIGN_NOT_IN_PROGRESS("현재 캠페인이 진행 중이지 않습니다."),
     CAMPAIGN_ALREADY_IN_PROGRESS("캠페인이 이미 진행 중 입니다."),
     STOCK_NOT_AVAILABLE("재고 수량은 최소 1개 이상이어야 합니다."),

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -1,7 +1,8 @@
 package cholog.wiseshop.domain.campaign;
 
-import static cholog.wiseshop.domain.product.ProductRepositoryTest.getCreateProductRequest;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.doNothing;
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
@@ -17,10 +18,13 @@ import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.member.MemberRepository;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
+import cholog.wiseshop.db.stock.Stock;
+import cholog.wiseshop.db.stock.StockRepository;
+import cholog.wiseshop.exception.WiseShopErrorCode;
+import cholog.wiseshop.exception.WiseShopException;
+import cholog.wiseshop.fixture.ProductFixture;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,8 +41,8 @@ public class CampaignServiceTest extends BaseTest {
     @Autowired
     private MemberRepository memberRepository;
 
-//    @Autowired
-//    private ProductService productService;
+    @Autowired
+    private StockRepository stockRepository;
 
     @Autowired
     private CampaignService campaignService;
@@ -49,6 +53,7 @@ public class CampaignServiceTest extends BaseTest {
     @AfterEach
     public void cleanUp() {
         productRepository.deleteAllInBatch();
+        stockRepository.deleteAllInBatch();
         campaignRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
     }
@@ -104,133 +109,106 @@ public class CampaignServiceTest extends BaseTest {
         assertThat(findCampaign.getGoalQuantity()).isEqualTo(10);
     }
 
-//
-//    @Test
-//    void 캠페인_조회하기() {
-//        // given
-//        CreateProductRequest request = getCreateProductRequest();
-//
-//        // when
-//        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
-//        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
-//        int goalQuantity = 5;
-//
-//        Long campaignId = campaignService.createCampaign(
-//            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
-//        ReadCampaignResponse response = campaignService.readCampaign(campaignId);
-//
-//        // then
-//        assertAll(
-//            () -> assertThat(response.campaignId()).isEqualTo(campaignId),
-//            () -> assertThat(response.product().name()).isEqualTo(request.name()),
-//            () -> assertThat(response.product().description()).isEqualTo(request.description()),
-//            () -> assertThat(response.product().price()).isEqualTo(request.price()),
-//            () -> assertThat(response.product().totalQuantity()).isEqualTo(request.totalQuantity())
-//        );
-//    }
-//
-//    @Test
-//    void 캠페인_조회하기_예외_잘못된_캠페인ID() {
-//        // given
-//        CreateProductRequest request = getCreateProductRequest();
-//
-//        // when
-//        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
-//        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
-//        int goalQuantity = 5;
-//
-//        Long campaignId = campaignService.createCampaign(
-//            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
-//        Long wrongId = campaignId + 1;
-//
-//        // then
-//        assertThatThrownBy(() -> campaignService.readCampaign(wrongId))
-//            .isInstanceOf(IllegalArgumentException.class);
-//    }
-//
-//    @Test
-//    void 캠페인_시작_상태_변경_성공() {
-//        // given
-//        CreateProductRequest request = getCreateProductRequest();
-//
-//        // when
-//        LocalDateTime startDate = LocalDateTime.now().plus(50, ChronoUnit.MILLIS);
-//        LocalDateTime endDate = LocalDateTime.now().plusMinutes(10);
-//        int goalQuantity = 5;
-//
-//        Long campaignId = campaignService.createCampaign(
-//            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
-//
-//        // then
-//        Awaitility.await()
-//            .dontCatchUncaughtExceptions()
-//            .until(() -> {
-//                Campaign modifiedCampaign = campaignRepository.findById(campaignId)
-//                    .orElseThrow();
-//                return modifiedCampaign.getState().equals(CampaignState.IN_PROGRESS);
-//            });
-//    }
-//
-//    @Test
-//    void 캠페인_실패_상태_변경_성공() {
-//        // given
-//        CreateProductRequest request = getCreateProductRequest();
-//
-//        // when
-//        LocalDateTime startDate = LocalDateTime.now();
-//        LocalDateTime endDate = LocalDateTime.now().plus(100, ChronoUnit.MILLIS);
-//        int goalQuantity = 5;
-//
-//        Long campaignId = campaignService.createCampaign(
-//            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
-//        Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
-//
-//        // then
-//        Awaitility.await()
-//            .dontCatchUncaughtExceptions()
-//            .atMost(200, TimeUnit.MILLISECONDS)
-//            .untilAsserted(() -> {
-//                Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
-//                    .orElseThrow();
-//                assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.FAILED);
-//            });
-//    }
-//
-//    @Test
-//    void 캠페인이_시작됐는지_확인() {
-//        // given
-//        CreateProductRequest request = getCreateProductRequest();
-//        productService.createProduct(request);
-//
-//        // when
-//        LocalDateTime startDate = LocalDateTime.now().plusSeconds(1);
-//        LocalDateTime endDate = LocalDateTime.now().plusSeconds(10);
-//        int goalQuantity = 5;
-//
-//        Long campaignId = campaignService.createCampaign(
-//            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
-//        // then
-//        Awaitility.await()
-//            .atLeast(1, TimeUnit.SECONDS)
-//            .untilAsserted(() -> assertThat(campaignService.isStarted(campaignId)).isTrue());
-//    }
+
+    @Test
+    void 캠페인_조회하기() {
+        // given
+        CreateProductRequest request = ProductFixture.getCreateProductRequest();
+        Member member = new Member("123@123.123", "김수민", "비밀번호");
+        memberRepository.save(member);
+        Stock stock = stockRepository.save(new Stock(request.totalQuantity()));
+        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+        Campaign campaign = campaignRepository.save(new Campaign(
+            startDate,
+            endDate,
+            2,
+            member
+        ));
+        productRepository.save(new Product(
+            request.name(),
+            request.description(),
+            request.price(),
+            campaign,
+            stock
+        ));
+
+        // when
+        ReadCampaignResponse response = campaignService.readCampaign(campaign.getId());
+
+        // then
+        assertAll(
+            () -> assertThat(response.campaignId()).isEqualTo(campaign.getId()),
+            () -> assertThat(response.product().name()).isEqualTo(request.name()),
+            () -> assertThat(response.product().description()).isEqualTo(request.description()),
+            () -> assertThat(response.product().price()).isEqualTo(request.price()),
+            () -> assertThat(response.product().totalQuantity()).isEqualTo(request.totalQuantity())
+        );
+    }
+
+    @Test
+    void 캠페인_조회하기_예외_잘못된_캠페인ID() {
+        // given
+        CreateProductRequest request = ProductFixture.getCreateProductRequest();
+        Member member = new Member("123@123.123", "김수민", "비밀번호");
+        memberRepository.save(member);
+        Stock stock = stockRepository.save(new Stock(request.totalQuantity()));
+        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+        Campaign campaign = campaignRepository.save(new Campaign(
+            startDate,
+            endDate,
+            2,
+            member
+        ));
+        productRepository.save(new Product(
+            request.name(),
+            request.description(),
+            request.price(),
+            campaign,
+            stock
+        ));
+        Long wrongId = campaign.getId() + 1;
+
+        // then
+        assertThatThrownBy(() -> campaignService.readCampaign(wrongId))
+            .isInstanceOf(WiseShopException.class)
+            .hasMessage(WiseShopErrorCode.CAMPAIGN_NOT_FOUND.getMessage());
+    }
 
     @Test
     void 기간_내_캠페인_전체조회_확인() {
         // given
-        CreateProductRequest request = getCreateProductRequest();
-        LocalDateTime startDate = LocalDateTime.now().plusSeconds(1);
-        LocalDateTime endDate = LocalDateTime.now().plusSeconds(2);
-        int goalQuantity = 5;
-        campaignService.createCampaign(
-            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
+        setData();
 
         // when
         List<ReadCampaignResponse> result = campaignService.readAllCampaign();
 
         // then
-        Awaitility.await()
-            .atMost(101, TimeUnit.MILLISECONDS)
-            .untilAsserted(() -> assertThat(result).hasSize(1));
+        assertThat(result).hasSize(5);
+    }
+
+    void setData() {
+        CreateProductRequest request = ProductFixture.getCreateProductRequest();
+        Member member = new Member("123@123.123", "김수민", "비밀번호");
+        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+        for (int i = 0; i < 5; i++) {
+            memberRepository.save(member);
+            Stock stock = stockRepository.save(new Stock(request.totalQuantity()));
+            Campaign campaign = campaignRepository.save(new Campaign(
+                startDate,
+                endDate,
+                2,
+                member
+            ));
+            productRepository.save(new Product(
+                request.name(),
+                request.description(),
+                request.price(),
+                campaign,
+                stock
+            ));
+        }
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -202,9 +202,9 @@ public class CampaignServiceTest extends BaseTest {
         }
 
         // when
-        List<ReadCampaignResponse> result = campaignService.readAllCampaign();
+        List<ReadCampaignResponse> allCampaign = campaignService.readAllCampaign();
 
         // then
-        assertThat(result).hasSize(5);
+        assertThat(allCampaign).hasSize(5);
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -73,7 +73,7 @@ public class CampaignServiceTest extends BaseTest {
         );
 
         // when
-        doNothing().when(scheduler).scheduleCampaignByDate(new Campaign());
+        doNothing().when(scheduler).scheduleCampaign(new Campaign());
         CreateCampaignResponse campaign = campaignService.createCampaign(request, member);
 
         // then
@@ -98,7 +98,7 @@ public class CampaignServiceTest extends BaseTest {
         );
 
         // when
-        doNothing().when(scheduler).scheduleCampaignByDate(new Campaign());
+        doNothing().when(scheduler).scheduleCampaign(new Campaign());
 
         CreateCampaignResponse campaign = campaignService.createCampaign(request, member);
         Campaign findCampaign = campaignRepository.findById(campaign.campaignId()).orElseThrow();

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -179,16 +179,6 @@ public class CampaignServiceTest extends BaseTest {
     @Test
     void 기간_내_캠페인_전체조회_확인() {
         // given
-        setData();
-
-        // when
-        List<ReadCampaignResponse> result = campaignService.readAllCampaign();
-
-        // then
-        assertThat(result).hasSize(5);
-    }
-
-    void setData() {
         CreateProductRequest request = ProductFixture.getCreateProductRequest();
         Member member = new Member("123@123.123", "김수민", "비밀번호");
         LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
@@ -210,5 +200,11 @@ public class CampaignServiceTest extends BaseTest {
                 stock
             ));
         }
+
+        // when
+        List<ReadCampaignResponse> result = campaignService.readAllCampaign();
+
+        // then
+        assertThat(result).hasSize(5);
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -181,10 +181,10 @@ public class CampaignServiceTest extends BaseTest {
         // given
         CreateProductRequest request = ProductFixture.getCreateProductRequest();
         Member member = new Member("123@123.123", "김수민", "비밀번호");
+        memberRepository.save(member);
         LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
         LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
         for (int i = 0; i < 5; i++) {
-            memberRepository.save(member);
             Stock stock = stockRepository.save(new Stock(request.totalQuantity()));
             Campaign campaign = campaignRepository.save(new Campaign(
                 startDate,

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -2,181 +2,218 @@ package cholog.wiseshop.domain.campaign;
 
 import static cholog.wiseshop.domain.product.ProductRepositoryTest.getCreateProductRequest;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.doNothing;
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
+import cholog.wiseshop.api.campaign.dto.response.CreateCampaignResponse;
 import cholog.wiseshop.api.campaign.dto.response.ReadCampaignResponse;
 import cholog.wiseshop.api.campaign.service.CampaignService;
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
-import cholog.wiseshop.api.product.service.ProductService;
 import cholog.wiseshop.common.BaseTest;
+import cholog.wiseshop.common.ThreadTaskScheduler;
 import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.campaign.CampaignRepository;
-import cholog.wiseshop.db.campaign.CampaignState;
+import cholog.wiseshop.db.member.Member;
+import cholog.wiseshop.db.member.MemberRepository;
+import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 public class CampaignServiceTest extends BaseTest {
-
-    @Autowired
-    private CampaignService campaignService;
 
     @Autowired
     private CampaignRepository campaignRepository;
 
     @Autowired
-    private ProductService productService;
-
-    @Autowired
     private ProductRepository productRepository;
 
-    @BeforeEach
+    @Autowired
+    private MemberRepository memberRepository;
+
+//    @Autowired
+//    private ProductService productService;
+
+    @Autowired
+    private CampaignService campaignService;
+
+    @MockitoBean
+    private ThreadTaskScheduler scheduler;
+
+    @AfterEach
     public void cleanUp() {
-        productRepository.deleteAll();
-        campaignRepository.deleteAll();
+        productRepository.deleteAllInBatch();
+        campaignRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
     }
 
     @Test
-    void 캠페인_추가하기() {
+    void 캠페인_생성_성공() {
         // given
-        CreateProductRequest request = getCreateProductRequest();
-
-        // when
-        LocalDateTime startDate = LocalDateTime.now().plusMinutes(1);
-        LocalDateTime endDate = LocalDateTime.now().plusMinutes(2);
-        Integer goalQuantity = 5;
-
-        Long campaignId = campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
-        Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
-
-        // then
-        assertThat(findCampaign.getStartDate().truncatedTo(ChronoUnit.SECONDS))
-                .isEqualTo(startDate.truncatedTo(ChronoUnit.SECONDS));
-        assertThat(findCampaign.getEndDate().truncatedTo(ChronoUnit.SECONDS))
-                .isEqualTo(endDate.truncatedTo(ChronoUnit.SECONDS));
-        assertThat(findCampaign.getGoalQuantity()).isEqualTo(goalQuantity);
-        assertThat(findCampaign.getState()).isEqualTo(CampaignState.WAITING);
-    }
-
-
-    @Test
-    void 캠페인_조회하기() {
-        // given
-        CreateProductRequest request = getCreateProductRequest();
-
-        // when
-        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
-        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
-        int goalQuantity = 5;
-
-        Long campaignId = campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
-        ReadCampaignResponse response = campaignService.readCampaign(campaignId);
-
-        // then
-        assertAll(
-                () -> assertThat(response.campaignId()).isEqualTo(campaignId),
-                () -> assertThat(response.product().name()).isEqualTo(request.name()),
-                () -> assertThat(response.product().description()).isEqualTo(request.description()),
-                () -> assertThat(response.product().price()).isEqualTo(request.price()),
-                () -> assertThat(response.product().totalQuantity()).isEqualTo(request.totalQuantity())
+        Member member = new Member("123@123.123", "김수민", "비밀번호");
+        memberRepository.save(member);
+        LocalDateTime startTime = LocalDateTime.now();
+        LocalDateTime endTime = LocalDateTime.now();
+        CreateCampaignRequest request = new CreateCampaignRequest(
+            startTime,
+            endTime,
+            10,
+            new CreateProductRequest("상품이름", "상품설명", 2000, 20)
         );
+
+        // when
+        doNothing().when(scheduler).scheduleCampaignByDate(new Campaign());
+        CreateCampaignResponse campaign = campaignService.createCampaign(request, member);
+
+        // then
+        assertThat(campaignRepository.findById(campaign.campaignId())).isNotEmpty();
+        List<Product> product = productRepository.findProductsByCampaignId(campaign.campaignId());
+        assertThat(product).isNotEmpty();
+        assertThat(product.getFirst().getStock()).isNotNull();
     }
 
     @Test
-    void 캠페인_조회하기_예외_잘못된_캠페인ID() {
+    void 캠페인_상세_정보_검증하기() {
         // given
-        CreateProductRequest request = getCreateProductRequest();
+        Member member = new Member("123@123.123", "김수민", "비밀번호");
+        memberRepository.save(member);
+        LocalDateTime startTime = LocalDateTime.of(2025, 3, 3, 3, 3);
+        LocalDateTime endTime = LocalDateTime.of(2025, 4, 4, 4, 4);
+        CreateCampaignRequest request = new CreateCampaignRequest(
+            startTime,
+            endTime,
+            10,
+            new CreateProductRequest("상품이름", "상품설명", 2000, 20)
+        );
 
         // when
-        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
-        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
-        int goalQuantity = 5;
+        doNothing().when(scheduler).scheduleCampaignByDate(new Campaign());
 
-        Long campaignId = campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
-        Long wrongId = campaignId + 1;
+        CreateCampaignResponse campaign = campaignService.createCampaign(request, member);
+        Campaign findCampaign = campaignRepository.findById(campaign.campaignId()).orElseThrow();
 
         // then
-        assertThatThrownBy(() -> campaignService.readCampaign(wrongId))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThat(findCampaign.getStartDate()).isEqualTo(startTime);
+        assertThat(findCampaign.getEndDate()).isEqualTo(endTime);
+        assertThat(findCampaign.getGoalQuantity()).isEqualTo(10);
     }
 
-    @Test
-    void 캠페인_시작_상태_변경_성공() {
-        // given
-        CreateProductRequest request = getCreateProductRequest();
-
-        // when
-        LocalDateTime startDate = LocalDateTime.now().plus(50, ChronoUnit.MILLIS);
-        LocalDateTime endDate = LocalDateTime.now().plusMinutes(10);
-        int goalQuantity = 5;
-
-        Long campaignId = campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
-
-        // then
-        Awaitility.await()
-                .dontCatchUncaughtExceptions()
-                .until(() -> {
-                    Campaign modifiedCampaign = campaignRepository.findById(campaignId)
-                            .orElseThrow();
-                    return modifiedCampaign.getState().equals(CampaignState.IN_PROGRESS);
-                });
-    }
-
-    @Test
-    void 캠페인_실패_상태_변경_성공() {
-        // given
-        CreateProductRequest request = getCreateProductRequest();
-
-        // when
-        LocalDateTime startDate = LocalDateTime.now();
-        LocalDateTime endDate = LocalDateTime.now().plus(100, ChronoUnit.MILLIS);
-        int goalQuantity = 5;
-
-        Long campaignId = campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
-        Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
-
-        // then
-        Awaitility.await()
-                .dontCatchUncaughtExceptions()
-                .atMost(200, TimeUnit.MILLISECONDS)
-                .untilAsserted(() -> {
-                    Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
-                            .orElseThrow();
-                    assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.FAILED);
-                });
-    }
-
-    @Test
-    void 캠페인이_시작됐는지_확인() {
-        // given
-        CreateProductRequest request = getCreateProductRequest();
-        productService.createProduct(request);
-
-        // when
-        LocalDateTime startDate = LocalDateTime.now().plusSeconds(1);
-        LocalDateTime endDate = LocalDateTime.now().plusSeconds(10);
-        int goalQuantity = 5;
-
-        Long campaignId = campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
-        // then
-        Awaitility.await()
-                .atLeast(1, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertThat(campaignService.isStarted(campaignId)).isTrue());
-    }
+//
+//    @Test
+//    void 캠페인_조회하기() {
+//        // given
+//        CreateProductRequest request = getCreateProductRequest();
+//
+//        // when
+//        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+//        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+//        int goalQuantity = 5;
+//
+//        Long campaignId = campaignService.createCampaign(
+//            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
+//        ReadCampaignResponse response = campaignService.readCampaign(campaignId);
+//
+//        // then
+//        assertAll(
+//            () -> assertThat(response.campaignId()).isEqualTo(campaignId),
+//            () -> assertThat(response.product().name()).isEqualTo(request.name()),
+//            () -> assertThat(response.product().description()).isEqualTo(request.description()),
+//            () -> assertThat(response.product().price()).isEqualTo(request.price()),
+//            () -> assertThat(response.product().totalQuantity()).isEqualTo(request.totalQuantity())
+//        );
+//    }
+//
+//    @Test
+//    void 캠페인_조회하기_예외_잘못된_캠페인ID() {
+//        // given
+//        CreateProductRequest request = getCreateProductRequest();
+//
+//        // when
+//        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30);
+//        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30);
+//        int goalQuantity = 5;
+//
+//        Long campaignId = campaignService.createCampaign(
+//            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
+//        Long wrongId = campaignId + 1;
+//
+//        // then
+//        assertThatThrownBy(() -> campaignService.readCampaign(wrongId))
+//            .isInstanceOf(IllegalArgumentException.class);
+//    }
+//
+//    @Test
+//    void 캠페인_시작_상태_변경_성공() {
+//        // given
+//        CreateProductRequest request = getCreateProductRequest();
+//
+//        // when
+//        LocalDateTime startDate = LocalDateTime.now().plus(50, ChronoUnit.MILLIS);
+//        LocalDateTime endDate = LocalDateTime.now().plusMinutes(10);
+//        int goalQuantity = 5;
+//
+//        Long campaignId = campaignService.createCampaign(
+//            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
+//
+//        // then
+//        Awaitility.await()
+//            .dontCatchUncaughtExceptions()
+//            .until(() -> {
+//                Campaign modifiedCampaign = campaignRepository.findById(campaignId)
+//                    .orElseThrow();
+//                return modifiedCampaign.getState().equals(CampaignState.IN_PROGRESS);
+//            });
+//    }
+//
+//    @Test
+//    void 캠페인_실패_상태_변경_성공() {
+//        // given
+//        CreateProductRequest request = getCreateProductRequest();
+//
+//        // when
+//        LocalDateTime startDate = LocalDateTime.now();
+//        LocalDateTime endDate = LocalDateTime.now().plus(100, ChronoUnit.MILLIS);
+//        int goalQuantity = 5;
+//
+//        Long campaignId = campaignService.createCampaign(
+//            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
+//        Campaign findCampaign = campaignRepository.findById(campaignId).orElseThrow();
+//
+//        // then
+//        Awaitility.await()
+//            .dontCatchUncaughtExceptions()
+//            .atMost(200, TimeUnit.MILLISECONDS)
+//            .untilAsserted(() -> {
+//                Campaign modifiedCampaign = campaignRepository.findById(findCampaign.getId())
+//                    .orElseThrow();
+//                assertThat(modifiedCampaign.getState()).isEqualTo(CampaignState.FAILED);
+//            });
+//    }
+//
+//    @Test
+//    void 캠페인이_시작됐는지_확인() {
+//        // given
+//        CreateProductRequest request = getCreateProductRequest();
+//        productService.createProduct(request);
+//
+//        // when
+//        LocalDateTime startDate = LocalDateTime.now().plusSeconds(1);
+//        LocalDateTime endDate = LocalDateTime.now().plusSeconds(10);
+//        int goalQuantity = 5;
+//
+//        Long campaignId = campaignService.createCampaign(
+//            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
+//        // then
+//        Awaitility.await()
+//            .atLeast(1, TimeUnit.SECONDS)
+//            .untilAsserted(() -> assertThat(campaignService.isStarted(campaignId)).isTrue());
+//    }
 
     @Test
     void 기간_내_캠페인_전체조회_확인() {
@@ -186,14 +223,14 @@ public class CampaignServiceTest extends BaseTest {
         LocalDateTime endDate = LocalDateTime.now().plusSeconds(2);
         int goalQuantity = 5;
         campaignService.createCampaign(
-                new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
+            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
 
         // when
         List<ReadCampaignResponse> result = campaignService.readAllCampaign();
 
         // then
         Awaitility.await()
-                .atMost(101, TimeUnit.MILLISECONDS)
-                .untilAsserted(() -> assertThat(result).hasSize(1));
+            .atMost(101, TimeUnit.MILLISECONDS)
+            .untilAsserted(() -> assertThat(result).hasSize(1));
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/campaign/CampaignServiceTest.java
@@ -78,9 +78,9 @@ public class CampaignServiceTest extends BaseTest {
 
         // then
         assertThat(campaignRepository.findById(campaign.campaignId())).isNotEmpty();
-        List<Product> product = productRepository.findProductsByCampaignId(campaign.campaignId());
-        assertThat(product).isNotEmpty();
-        assertThat(product.getFirst().getStock()).isNotNull();
+        List<Product> products = productRepository.findProductsByCampaignId(campaign.campaignId());
+        assertThat(products).isNotEmpty();
+        assertThat(products.getFirst().getStock()).isNotNull();
     }
 
     @Test

--- a/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
@@ -163,62 +163,62 @@ public class ProductServiceTest extends BaseTest {
             .isInstanceOf(WiseShopException.class)
             .hasMessage(WiseShopErrorCode.MODIFY_PRICE_PRODUCT_NOT_FOUND.getMessage());
     }
+//
+//    @Test
+//    void 상품_재고_수량_수정_성공() {
+//        // given
+//        CreateProductRequest request = getCreateProductRequest();
+//        Long productId = productService.createProduct(request);
+//
+//        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30, 10);
+//        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30, 10);
+//        int goalQuantity = 5;
+//
+//        Long campaignId = campaignService.createCampaign(
+//            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
+//        Integer modifyQuantity = 1;
+//
+//        // when
+//        ModifyQuantityRequest modifyQuantityRequest = new ModifyQuantityRequest(
+//            campaignId,
+//            productId,
+//            modifyQuantity
+//        );
+//        productService.modifyStockQuantity(modifyQuantityRequest);
+//
+//        Product modifiedProduct = productRepository.findById(productId)
+//            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다."));
+//        Stock modifiedStock = modifiedProduct.getStock();
+//
+//        // then
+//        assertThat(modifiedStock.getTotalQuantity()).isEqualTo(modifyQuantity);
+//    }
 
-    @Test
-    void 상품_재고_수량_수정_성공() {
-        // given
-        CreateProductRequest request = getCreateProductRequest();
-        Long productId = productService.createProduct(request);
-
-        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30, 10);
-        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30, 10);
-        int goalQuantity = 5;
-
-        Long campaignId = campaignService.createCampaign(
-            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
-        Integer modifyQuantity = 1;
-
-        // when
-        ModifyQuantityRequest modifyQuantityRequest = new ModifyQuantityRequest(
-            campaignId,
-            productId,
-            modifyQuantity
-        );
-        productService.modifyStockQuantity(modifyQuantityRequest);
-
-        Product modifiedProduct = productRepository.findById(productId)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다."));
-        Stock modifiedStock = modifiedProduct.getStock();
-
-        // then
-        assertThat(modifiedStock.getTotalQuantity()).isEqualTo(modifyQuantity);
-    }
-
-    @Test
-    void 상품_재고_수량_수정_실패() {
-        // given
-        CreateProductRequest request = getCreateProductRequest();
-        Long productId = productService.createProduct(request);
-
-        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30, 10);
-        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30, 10);
-        int goalQuantity = 5;
-
-        Long campaignId = campaignService.createCampaign(
-            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
-        Integer modifyQuantity = 0;
-
-        // when
-        ModifyQuantityRequest modifyQuantityRequest = new ModifyQuantityRequest(
-            campaignId,
-            productId,
-            modifyQuantity
-        );
-
-        // then
-        assertThatThrownBy(() -> productService.modifyStockQuantity(modifyQuantityRequest))
-            .isInstanceOf(WiseShopException.class).hasMessage(WiseShopErrorCode.STOCK_NOT_AVAILABLE.getMessage());
-    }
+//    @Test
+//    void 상품_재고_수량_수정_실패() {
+//        // given
+//        CreateProductRequest request = getCreateProductRequest();
+//        Long productId = productService.createProduct(request);
+//
+//        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30, 10);
+//        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30, 10);
+//        int goalQuantity = 5;
+//
+//        Long campaignId = campaignService.createCampaign(
+//            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
+//        Integer modifyQuantity = 0;
+//
+//        // when
+//        ModifyQuantityRequest modifyQuantityRequest = new ModifyQuantityRequest(
+//            campaignId,
+//            productId,
+//            modifyQuantity
+//        );
+//
+//        // then
+//        assertThatThrownBy(() -> productService.modifyStockQuantity(modifyQuantityRequest))
+//            .isInstanceOf(WiseShopException.class).hasMessage(WiseShopErrorCode.STOCK_NOT_AVAILABLE.getMessage());
+//    }
 
     @Test
     void 상품과_재고_삭제하기() {

--- a/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/product/ProductServiceTest.java
@@ -4,12 +4,10 @@ import static cholog.wiseshop.domain.product.ProductRepositoryTest.getCreateProd
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
 import cholog.wiseshop.api.campaign.service.CampaignService;
 import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductPriceRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
-import cholog.wiseshop.api.product.dto.request.ModifyQuantityRequest;
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.api.product.service.ProductService;
 import cholog.wiseshop.common.BaseTest;
@@ -19,7 +17,6 @@ import cholog.wiseshop.db.stock.Stock;
 import cholog.wiseshop.db.stock.StockRepository;
 import cholog.wiseshop.exception.WiseShopErrorCode;
 import cholog.wiseshop.exception.WiseShopException;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -163,62 +160,9 @@ public class ProductServiceTest extends BaseTest {
             .isInstanceOf(WiseShopException.class)
             .hasMessage(WiseShopErrorCode.MODIFY_PRICE_PRODUCT_NOT_FOUND.getMessage());
     }
-//
-//    @Test
-//    void 상품_재고_수량_수정_성공() {
-//        // given
-//        CreateProductRequest request = getCreateProductRequest();
-//        Long productId = productService.createProduct(request);
-//
-//        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30, 10);
-//        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30, 10);
-//        int goalQuantity = 5;
-//
-//        Long campaignId = campaignService.createCampaign(
-//            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
-//        Integer modifyQuantity = 1;
-//
-//        // when
-//        ModifyQuantityRequest modifyQuantityRequest = new ModifyQuantityRequest(
-//            campaignId,
-//            productId,
-//            modifyQuantity
-//        );
-//        productService.modifyStockQuantity(modifyQuantityRequest);
-//
-//        Product modifiedProduct = productRepository.findById(productId)
-//            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다."));
-//        Stock modifiedStock = modifiedProduct.getStock();
-//
-//        // then
-//        assertThat(modifiedStock.getTotalQuantity()).isEqualTo(modifyQuantity);
-//    }
 
-//    @Test
-//    void 상품_재고_수량_수정_실패() {
-//        // given
-//        CreateProductRequest request = getCreateProductRequest();
-//        Long productId = productService.createProduct(request);
-//
-//        LocalDateTime startDate = LocalDateTime.of(2025, 1, 7, 10, 30, 10);
-//        LocalDateTime endDate = LocalDateTime.of(2025, 1, 8, 10, 30, 10);
-//        int goalQuantity = 5;
-//
-//        Long campaignId = campaignService.createCampaign(
-//            new CreateCampaignRequest(startDate, endDate, goalQuantity, request), null);
-//        Integer modifyQuantity = 0;
-//
-//        // when
-//        ModifyQuantityRequest modifyQuantityRequest = new ModifyQuantityRequest(
-//            campaignId,
-//            productId,
-//            modifyQuantity
-//        );
-//
-//        // then
-//        assertThatThrownBy(() -> productService.modifyStockQuantity(modifyQuantityRequest))
-//            .isInstanceOf(WiseShopException.class).hasMessage(WiseShopErrorCode.STOCK_NOT_AVAILABLE.getMessage());
-//    }
+    // TODO: 상품 재고 수량 수정 성공 테스트 작성
+    // TODO: 상품 재고 수량 수정 실패 테스트 작성
 
     @Test
     void 상품과_재고_삭제하기() {

--- a/src/test/java/cholog/wiseshop/fixture/ProductFixture.java
+++ b/src/test/java/cholog/wiseshop/fixture/ProductFixture.java
@@ -1,0 +1,15 @@
+package cholog.wiseshop.fixture;
+
+import cholog.wiseshop.api.product.dto.request.CreateProductRequest;
+
+public class ProductFixture {
+
+    public static CreateProductRequest getCreateProductRequest() {
+        String name = "보약";
+        String description = "먹으면 기분이 좋아져요.";
+        int price = 10000;
+        int totalQuantity = 5;
+
+        return new CreateProductRequest(name, description, price, totalQuantity);
+    }
+}


### PR DESCRIPTION
## 작업내용
캠페인 로직을 수정했습니다.
스케줄러를 클래스 분리하여 역할을 분리해주었고, 이에 따라 테스트에서도 스케줄러 클래스는 mock 처리해주어요!! 그래서 이제 시간이 많이 줄었어요
스케줄러 로직도 반드시 테스트해야하기 때문에, 이는 따로 스케줄러 테스트를 작성할 예정입니다.
그리고 Product에 Stock이 cascadeType.All 로 설정 되어있었는데요, 테스트를 작성하다가 stock이 영속화 되지 않는 문제가 있었어요. 구글링해보니 저 설정 문제였던 것 같아서 이거를 떼줬더니 잘 동작했습니다.
그리고 `deleteAllInBatch()`를 `@BeforeEach`로 해주면 자꾸 다른 클래스 테스트에서 테스트 분리가 잘 안되더라고요..그래서 다른 테스트 클래스에서 사용하지 않는 애도 `@AutoWired` 해주어야하는 문제가 있어서 `@AfterEach()`를 사용해줬는데 어떻게 생각하세요???
그리고 테스트에서 반복적으로 사용하는 메서드를 fixture파일로 분리해주었습니다. 다른 테스트 클래스의 메서드를 끌고와야 하더라구요.
