### PR TITLE
feat: 사용자는 사용자 정보를 관리할 수 있다.

### DIFF
--- a/src/main/java/cholog/wiseshop/api/address/controller/AddressController.java
+++ b/src/main/java/cholog/wiseshop/api/address/controller/AddressController.java
@@ -1,0 +1,30 @@
+package cholog.wiseshop.api.address.controller;
+
+import cholog.wiseshop.api.address.dto.CreateAddressRequest;
+import cholog.wiseshop.api.address.service.AddressService;
+import cholog.wiseshop.common.auth.Auth;
+import cholog.wiseshop.db.member.Member;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v1")
+@RestController
+public class AddressController {
+
+    private final AddressService addressService;
+
+    public AddressController(AddressService addressService) {
+        this.addressService = addressService;
+    }
+
+    @PostMapping("/member/address")
+    public ResponseEntity<Long> createAddress(
+        @Auth Member member,
+        @RequestBody CreateAddressRequest request
+    ) {
+        return ResponseEntity.ok().body(addressService.createAddress(request));
+    }
+}

--- a/src/main/java/cholog/wiseshop/api/address/controller/AddressController.java
+++ b/src/main/java/cholog/wiseshop/api/address/controller/AddressController.java
@@ -25,6 +25,6 @@ public class AddressController {
         @Auth Member member,
         @RequestBody CreateAddressRequest request
     ) {
-        return ResponseEntity.ok().body(addressService.createAddress(request));
+        return ResponseEntity.ok().body(addressService.createAddress(member, request));
     }
 }

--- a/src/main/java/cholog/wiseshop/api/address/controller/AddressController.java
+++ b/src/main/java/cholog/wiseshop/api/address/controller/AddressController.java
@@ -4,7 +4,10 @@ import cholog.wiseshop.api.address.dto.CreateAddressRequest;
 import cholog.wiseshop.api.address.service.AddressService;
 import cholog.wiseshop.common.auth.Auth;
 import cholog.wiseshop.db.member.Member;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,5 +29,11 @@ public class AddressController {
         @RequestBody CreateAddressRequest request
     ) {
         return ResponseEntity.ok().body(addressService.createAddress(member, request));
+    }
+
+    @DeleteMapping("/member/address/{id}")
+    public ResponseEntity<Void> deleteAddress(@Auth Member member, @PathVariable Long id) {
+        addressService.deleteAddress(member, id);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/cholog/wiseshop/api/address/dto/CreateAddressRequest.java
+++ b/src/main/java/cholog/wiseshop/api/address/dto/CreateAddressRequest.java
@@ -1,0 +1,10 @@
+package cholog.wiseshop.api.address.dto;
+
+public record CreateAddressRequest(
+    int postalCode,
+    String roadAddress,
+    String detailAddress,
+    boolean isDefault
+) {
+
+}

--- a/src/main/java/cholog/wiseshop/api/address/service/AddressService.java
+++ b/src/main/java/cholog/wiseshop/api/address/service/AddressService.java
@@ -4,6 +4,11 @@ import cholog.wiseshop.api.address.dto.CreateAddressRequest;
 import cholog.wiseshop.db.address.Address;
 import cholog.wiseshop.db.address.AddressRepository;
 import cholog.wiseshop.db.member.Member;
+import cholog.wiseshop.db.order.Order;
+import cholog.wiseshop.db.order.OrderRepository;
+import cholog.wiseshop.exception.WiseShopErrorCode;
+import cholog.wiseshop.exception.WiseShopException;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,13 +17,28 @@ import org.springframework.transaction.annotation.Transactional;
 public class AddressService {
 
     private final AddressRepository addressRepository;
+    private final OrderRepository orderRepository;
 
-    public AddressService(AddressRepository addressRepository) {
+    public AddressService(AddressRepository addressRepository, OrderRepository orderRepository) {
         this.addressRepository = addressRepository;
+        this.orderRepository = orderRepository;
     }
 
     public Long createAddress(Member member, CreateAddressRequest request) {
         Address address = Address.from(member, request);
         return addressRepository.save(address).getId();
+    }
+
+    public void deleteAddress(Member member, Long addressId) {
+        Address address = addressRepository.findById(addressId)
+            .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.ADDRESS_NOT_FOUND));
+        List<Order> orders = orderRepository.findByAddressId(address.getId());
+        /*
+        * 아래의 배송 정보 삭제 정책 이상해요 주문한 상품이 배송 완료, 배송 중인지를 모르니
+        * 그냥 주문 정보 있으면 삭제가 불가능하게 밖에 못했습니다.
+         */
+        if (orders.stream().anyMatch(it -> it.getAddress().equals(address))) {
+            throw new WiseShopException(WiseShopErrorCode.ADDRESS_EXIST_INTO_ORDER);
+        }
     }
 }

--- a/src/main/java/cholog/wiseshop/api/address/service/AddressService.java
+++ b/src/main/java/cholog/wiseshop/api/address/service/AddressService.java
@@ -1,0 +1,30 @@
+package cholog.wiseshop.api.address.service;
+
+import cholog.wiseshop.api.address.dto.CreateAddressRequest;
+import cholog.wiseshop.db.address.Address;
+import cholog.wiseshop.db.address.AddressRepository;
+import cholog.wiseshop.db.member.Member;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class AddressService {
+
+    private final AddressRepository addressRepository;
+
+    public AddressService(AddressRepository addressRepository) {
+        this.addressRepository = addressRepository;
+    }
+
+    public Long createAddress(Member member, CreateAddressRequest request) {
+        Address address = new Address(
+            request.postalCode(),
+            request.roadAddress(),
+            request.detailAddress(),
+            request.isDefault(),
+            member
+        );
+        return addressRepository.save(address).getId();
+    }
+}

--- a/src/main/java/cholog/wiseshop/api/address/service/AddressService.java
+++ b/src/main/java/cholog/wiseshop/api/address/service/AddressService.java
@@ -18,13 +18,7 @@ public class AddressService {
     }
 
     public Long createAddress(Member member, CreateAddressRequest request) {
-        Address address = new Address(
-            request.postalCode(),
-            request.roadAddress(),
-            request.detailAddress(),
-            request.isDefault(),
-            member
-        );
+        Address address = Address.from(member, request);
         return addressRepository.save(address).getId();
     }
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -89,19 +89,19 @@ public class CampaignService {
 		LocalDateTime startDate,
 		LocalDateTime endDate) {
 		Runnable startCampaign = () -> transactionTemplate.execute(status -> {
-			changeCampaingState(campaignId, CampaignState.IN_PROGRESS);
+			changeCampaignState(campaignId, CampaignState.IN_PROGRESS);
 			return null;
 		});
 		scheduler.schedule(startCampaign, startDate.atZone(ZoneId.systemDefault()).toInstant());
 
 		Runnable endCampaign = () -> transactionTemplate.execute(status -> {
-			changeCampaingState(campaignId, CampaignState.FAILED);
+			changeCampaignState(campaignId, CampaignState.FAILED);
 			return null;
 		});
 		scheduler.schedule(endCampaign, endDate.atZone(ZoneId.systemDefault()).toInstant());
 	}
 
-	public void changeCampaingState(Long campaignId, CampaignState state) {
+	public void changeCampaignState(Long campaignId, CampaignState state) {
 		Campaign campaign = campaignRepository.findById(campaignId)
 			.orElseThrow(() -> new IllegalArgumentException("상태 변경할 캠페인 정보가 존재하지 않습니다."));
 		campaign.updateState(state);

--- a/src/main/java/cholog/wiseshop/api/member/controller/MemberController.java
+++ b/src/main/java/cholog/wiseshop/api/member/controller/MemberController.java
@@ -41,7 +41,7 @@ public class MemberController {
     }
 
     @DeleteMapping("/member")
-    public ResponseEntity<Void> deleteAccount(@Auth Member member) {
+    public ResponseEntity<Void> deleteMember(@Auth Member member) {
         memberService.deleteMember(member);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/src/main/java/cholog/wiseshop/api/member/controller/MemberController.java
+++ b/src/main/java/cholog/wiseshop/api/member/controller/MemberController.java
@@ -3,9 +3,14 @@ package cholog.wiseshop.api.member.controller;
 import cholog.wiseshop.api.member.dto.request.SignInRequest;
 import cholog.wiseshop.api.member.dto.request.SignUpRequest;
 import cholog.wiseshop.api.member.service.MemberService;
+import cholog.wiseshop.common.auth.Auth;
+import cholog.wiseshop.db.member.Member;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,5 +38,11 @@ public class MemberController {
         HttpSession session = httpServletRequest.getSession();
         memberService.signInMember(signInRequest, session);
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/member")
+    public ResponseEntity<Void> deleteAccount(@Auth Member member) {
+        memberService.deleteMember(member);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/cholog/wiseshop/api/member/service/MemberService.java
+++ b/src/main/java/cholog/wiseshop/api/member/service/MemberService.java
@@ -19,45 +19,45 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class MemberService {
 
-	private static final String SESSION_KEY = "member";
-	private final MemberRepository memberRepository;
-	private final CampaignRepository campaignRepository;
-	private final PasswordEncoder passwordEncoder;
+    private static final String SESSION_KEY = "member";
+    private final MemberRepository memberRepository;
+    private final CampaignRepository campaignRepository;
+    private final PasswordEncoder passwordEncoder;
 
-	public MemberService(
-		MemberRepository memberRepository,
-		CampaignRepository campaignRepository,
-		PasswordEncoder passwordEncoder
-	) {
-		this.memberRepository = memberRepository;
-		this.campaignRepository = campaignRepository;
-		this.passwordEncoder = passwordEncoder;
-	}
+    public MemberService(
+        MemberRepository memberRepository,
+        CampaignRepository campaignRepository,
+        PasswordEncoder passwordEncoder
+    ) {
+        this.memberRepository = memberRepository;
+        this.campaignRepository = campaignRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
 
-	public void signUpMember(SignUpRequest signUpRequest) {
-		if (memberRepository.findByEmail(signUpRequest.email()).isPresent()) {
-			throw new WiseShopException(WiseShopErrorCode.ALREADY_EXIST_MEMBER);
-		}
-		String encodePassword = passwordEncoder.encode(signUpRequest.password());
-		Member member = new Member(signUpRequest.email(), signUpRequest.name(), encodePassword);
-		memberRepository.save(member);
-	}
+    public void signUpMember(SignUpRequest signUpRequest) {
+        if (memberRepository.findByEmail(signUpRequest.email()).isPresent()) {
+            throw new WiseShopException(WiseShopErrorCode.ALREADY_EXIST_MEMBER);
+        }
+        String encodePassword = passwordEncoder.encode(signUpRequest.password());
+        Member member = new Member(signUpRequest.email(), signUpRequest.name(), encodePassword);
+        memberRepository.save(member);
+    }
 
-	public void signInMember(SignInRequest signInRequest, HttpSession session) {
-		Member member = memberRepository.findByEmail(signInRequest.email())
-			.orElseThrow(() -> new WiseShopException(WiseShopErrorCode.MEMBER_ID_NOT_FOUND));
-		boolean matches = passwordEncoder.matches(signInRequest.password(), member.getPassword());
-		if (!matches) {
-			throw new WiseShopException(WiseShopErrorCode.MEMBER_ID_NOT_FOUND);
-		}
-		session.setAttribute(SESSION_KEY, member);
-	}
+    public void signInMember(SignInRequest signInRequest, HttpSession session) {
+        Member member = memberRepository.findByEmail(signInRequest.email())
+            .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.MEMBER_ID_NOT_FOUND));
+        boolean matches = passwordEncoder.matches(signInRequest.password(), member.getPassword());
+        if (!matches) {
+            throw new WiseShopException(WiseShopErrorCode.MEMBER_ID_NOT_FOUND);
+        }
+        session.setAttribute(SESSION_KEY, member);
+    }
 
-	public void deleteMember(Member member) {
-		List<Campaign> campaigns = campaignRepository.findCampaignByMemberId(member.getId());
-		if (campaigns.stream().anyMatch(it -> it.getState().equals(CampaignState.IN_PROGRESS))) {
-			throw new WiseShopException(WiseShopErrorCode.MEMBER_INPROGRESS_CAMPAIGN_EXIST);
-		}
-		memberRepository.deleteById(member.getId());
-	}
+    public void deleteMember(Member member) {
+        List<Campaign> campaigns = campaignRepository.findCampaignByMemberId(member.getId());
+        if (campaigns.stream().anyMatch(it -> it.getState().equals(CampaignState.IN_PROGRESS))) {
+            throw new WiseShopException(WiseShopErrorCode.MEMBER_INPROGRESS_CAMPAIGN_EXIST);
+        }
+        memberRepository.deleteById(member.getId());
+    }
 }

--- a/src/main/java/cholog/wiseshop/api/member/service/MemberService.java
+++ b/src/main/java/cholog/wiseshop/api/member/service/MemberService.java
@@ -2,11 +2,15 @@ package cholog.wiseshop.api.member.service;
 
 import cholog.wiseshop.api.member.dto.request.SignInRequest;
 import cholog.wiseshop.api.member.dto.request.SignUpRequest;
+import cholog.wiseshop.db.campaign.Campaign;
+import cholog.wiseshop.db.campaign.CampaignRepository;
+import cholog.wiseshop.db.campaign.CampaignState;
 import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.member.MemberRepository;
 import cholog.wiseshop.exception.WiseShopErrorCode;
 import cholog.wiseshop.exception.WiseShopException;
 import jakarta.servlet.http.HttpSession;
+import java.util.List;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,31 +19,45 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class MemberService {
 
-    private static final String SESSION_KEY = "member";
-    private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder;
+	private static final String SESSION_KEY = "member";
+	private final MemberRepository memberRepository;
+	private final CampaignRepository campaignRepository;
+	private final PasswordEncoder passwordEncoder;
 
-    public MemberService(MemberRepository memberRepository, PasswordEncoder passwordEncoder) {
-        this.memberRepository = memberRepository;
-        this.passwordEncoder = passwordEncoder;
-    }
+	public MemberService(
+		MemberRepository memberRepository,
+		CampaignRepository campaignRepository,
+		PasswordEncoder passwordEncoder
+	) {
+		this.memberRepository = memberRepository;
+		this.campaignRepository = campaignRepository;
+		this.passwordEncoder = passwordEncoder;
+	}
 
-    public void signUpMember(SignUpRequest signUpRequest) {
-        if (memberRepository.findByEmail(signUpRequest.email()).isPresent()) {
-            throw new WiseShopException(WiseShopErrorCode.ALREADY_EXIST_MEMBER);
-        }
-        String encodePassword = passwordEncoder.encode(signUpRequest.password());
-        Member member = new Member(signUpRequest.email(), signUpRequest.name(), encodePassword);
-        memberRepository.save(member);
-    }
+	public void signUpMember(SignUpRequest signUpRequest) {
+		if (memberRepository.findByEmail(signUpRequest.email()).isPresent()) {
+			throw new WiseShopException(WiseShopErrorCode.ALREADY_EXIST_MEMBER);
+		}
+		String encodePassword = passwordEncoder.encode(signUpRequest.password());
+		Member member = new Member(signUpRequest.email(), signUpRequest.name(), encodePassword);
+		memberRepository.save(member);
+	}
 
-    public void signInMember(SignInRequest signInRequest, HttpSession session) {
-        Member member = memberRepository.findByEmail(signInRequest.email())
-            .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.MEMBER_ID_NOT_FOUND));
-        boolean matches = passwordEncoder.matches(signInRequest.password(), member.getPassword());
-        if (!matches) {
-            throw new WiseShopException(WiseShopErrorCode.MEMBER_ID_NOT_FOUND);
-        }
-        session.setAttribute(SESSION_KEY, member);
-    }
+	public void signInMember(SignInRequest signInRequest, HttpSession session) {
+		Member member = memberRepository.findByEmail(signInRequest.email())
+			.orElseThrow(() -> new WiseShopException(WiseShopErrorCode.MEMBER_ID_NOT_FOUND));
+		boolean matches = passwordEncoder.matches(signInRequest.password(), member.getPassword());
+		if (!matches) {
+			throw new WiseShopException(WiseShopErrorCode.MEMBER_ID_NOT_FOUND);
+		}
+		session.setAttribute(SESSION_KEY, member);
+	}
+
+	public void deleteMember(Member member) {
+		List<Campaign> campaigns = campaignRepository.findCampaignByMemberId(member.getId());
+		if (campaigns.stream().anyMatch(it -> it.getState().equals(CampaignState.IN_PROGRESS))) {
+			throw new WiseShopException(WiseShopErrorCode.MEMBER_INPROGRESS_CAMPAIGN_EXIST);
+		}
+		memberRepository.deleteById(member.getId());
+	}
 }

--- a/src/main/java/cholog/wiseshop/api/order/controller/OrderController.java
+++ b/src/main/java/cholog/wiseshop/api/order/controller/OrderController.java
@@ -46,12 +46,6 @@ public class OrderController {
         return ResponseEntity.ok(response);
     }
 
-    @PatchMapping("/orders/{id}")
-    public ResponseEntity<Void> modifyOrderCount(@PathVariable Long id, @RequestBody ModifyOrderCountRequest request) {
-        orderService.modifyOrderCount(id, request);
-        return ResponseEntity.ok().build();
-    }
-
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteOrder(@PathVariable Long id) {
         orderService.deleteOrder(id);

--- a/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
+++ b/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
@@ -56,12 +56,6 @@ public class OrderService {
 			.stream().map(OrderResponse::new).toList();
 	}
 
-	public void modifyOrderCount(Long orderId, ModifyOrderCountRequest request) {
-		Order order = orderRepository.findById(orderId)
-			.orElseThrow(() -> new WiseShopException(WiseShopErrorCode.ORDER_NOT_FOUND));
-		order.updateCount(request.count());
-	}
-
 	public void deleteOrder(Long id) {
 		orderRepository.findById(id)
 			.orElseThrow(() -> new WiseShopException(WiseShopErrorCode.ORDER_NOT_FOUND));

--- a/src/main/java/cholog/wiseshop/db/address/Address.java
+++ b/src/main/java/cholog/wiseshop/db/address/Address.java
@@ -72,6 +72,10 @@ public class Address {
         return isDefault;
     }
 
+    public Member getMember() {
+        return member;
+    }
+
     public static Address from(Member member, CreateAddressRequest request) {
         return new Address(
             request.postalCode(),

--- a/src/main/java/cholog/wiseshop/db/address/Address.java
+++ b/src/main/java/cholog/wiseshop/db/address/Address.java
@@ -41,12 +41,14 @@ public class Address {
         int postalCode,
         String roadAddress,
         String detailAddress,
-        boolean isDefault
+        boolean isDefault,
+        Member member
     ) {
         this.postalCode = postalCode;
         this.roadAddress = roadAddress;
         this.detailAddress = detailAddress;
         this.isDefault = isDefault;
+        this.member = member
     }
 
     public Long getId() {

--- a/src/main/java/cholog/wiseshop/db/address/Address.java
+++ b/src/main/java/cholog/wiseshop/db/address/Address.java
@@ -1,0 +1,71 @@
+package cholog.wiseshop.db.address;
+
+import cholog.wiseshop.db.member.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Table(name = "ADDRESS")
+@Entity
+public class Address {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int postalCode;
+
+    @Column(name = "road_address", length = 200)
+    private String roadAddress;
+
+    @Column(name = "detail_address", length = 200)
+    private String detailAddress;
+
+    @Column(name = "is_default")
+    private boolean isDefault;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public Address() {
+    }
+
+    public Address(
+        int postalCode,
+        String roadAddress,
+        String detailAddress,
+        boolean isDefault
+    ) {
+        this.postalCode = postalCode;
+        this.roadAddress = roadAddress;
+        this.detailAddress = detailAddress;
+        this.isDefault = isDefault;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public int getPostalCode() {
+        return postalCode;
+    }
+
+    public String getRoadAddress() {
+        return roadAddress;
+    }
+
+    public String getDetailAddress() {
+        return detailAddress;
+    }
+
+    public boolean isDefault() {
+        return isDefault;
+    }
+}

--- a/src/main/java/cholog/wiseshop/db/address/Address.java
+++ b/src/main/java/cholog/wiseshop/db/address/Address.java
@@ -1,5 +1,6 @@
 package cholog.wiseshop.db.address;
 
+import cholog.wiseshop.api.address.dto.CreateAddressRequest;
 import cholog.wiseshop.db.member.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -48,7 +49,7 @@ public class Address {
         this.roadAddress = roadAddress;
         this.detailAddress = detailAddress;
         this.isDefault = isDefault;
-        this.member = member
+        this.member = member;
     }
 
     public Long getId() {
@@ -69,5 +70,15 @@ public class Address {
 
     public boolean isDefault() {
         return isDefault;
+    }
+
+    public static Address from(Member member, CreateAddressRequest request) {
+        return new Address(
+            request.postalCode(),
+            request.roadAddress(),
+            request.detailAddress(),
+            request.isDefault(),
+            member
+        );
     }
 }

--- a/src/main/java/cholog/wiseshop/db/address/AddressRepository.java
+++ b/src/main/java/cholog/wiseshop/db/address/AddressRepository.java
@@ -1,0 +1,7 @@
+package cholog.wiseshop.db.address;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AddressRepository extends JpaRepository<Address, Long> {
+
+}

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -41,7 +41,7 @@ public class Campaign {
     private CampaignState state;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "MEMBER_ID")
+    @JoinColumn(name = "member_id")
     private Member member;
 
     public Campaign(LocalDateTime startDate,

--- a/src/main/java/cholog/wiseshop/db/campaign/CampaignRepository.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/CampaignRepository.java
@@ -1,7 +1,9 @@
 package cholog.wiseshop.db.campaign;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CampaignRepository extends JpaRepository<Campaign, Long> {
 
+	List<Campaign> findCampaignByMemberId(Long memberId);
 }

--- a/src/main/java/cholog/wiseshop/db/member/Member.java
+++ b/src/main/java/cholog/wiseshop/db/member/Member.java
@@ -28,19 +28,23 @@ public class Member {
     @Column(name = "password", nullable = false)
     private String password;
 
-    public Member(Long id,
-                  String email,
-                  String name,
-                  String password) {
+    public Member(
+        Long id,
+        String email,
+        String name,
+        String password
+    ) {
         this.id = id;
         this.email = email;
         this.name = name;
         this.password = password;
     }
 
-    public Member(String email,
-                  String name,
-                  String password) {
+    public Member(
+        String email,
+        String name,
+        String password
+    ) {
         this.email = email;
         this.name = name;
         this.password = password;

--- a/src/main/java/cholog/wiseshop/db/member/Member.java
+++ b/src/main/java/cholog/wiseshop/db/member/Member.java
@@ -17,11 +17,11 @@ public class Member {
     private Long id;
 
     @NotNull
-    @Column(name = "member_email", nullable = false)
+    @Column(name = "email", nullable = false)
     private String email;
 
     @NotNull
-    @Column(name = "member_name", nullable = false)
+    @Column(name = "name", nullable = false)
     private String name;
 
     @NotNull

--- a/src/main/java/cholog/wiseshop/db/order/Order.java
+++ b/src/main/java/cholog/wiseshop/db/order/Order.java
@@ -33,8 +33,8 @@ public class Order extends BaseTimeEntity {
     private Member member;
 
     @OneToOne
-    @JoinColumn(name = "shipping_address_id")
-    private Address shippingAddress;
+    @JoinColumn(name = "address_id")
+    private Address address;
 
     public Order() {
     }
@@ -43,12 +43,12 @@ public class Order extends BaseTimeEntity {
         int count,
         Product product,
         Member member,
-        Address shippingAddress
+        Address address
     ) {
         this.count = count;
         this.product = product;
         this.member = member;
-        this.shippingAddress = shippingAddress;
+        this.address = address;
     }
 
     public Long getId() {
@@ -67,7 +67,7 @@ public class Order extends BaseTimeEntity {
         return member;
     }
 
-    public Address getShippingAddress() {
-        return shippingAddress;
+    public Address getAddress() {
+        return address;
     }
 }

--- a/src/main/java/cholog/wiseshop/db/order/Order.java
+++ b/src/main/java/cholog/wiseshop/db/order/Order.java
@@ -22,11 +22,11 @@ public class Order extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "PRODUCT_ID", unique = false)
+    @JoinColumn(name = "product_id", unique = false)
     private Product product;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "MEMBER_ID")
+    @JoinColumn(name = "member_id")
     private Member member;
 
     private int count;

--- a/src/main/java/cholog/wiseshop/db/order/Order.java
+++ b/src/main/java/cholog/wiseshop/db/order/Order.java
@@ -1,6 +1,7 @@
 package cholog.wiseshop.db.order;
 
 import cholog.wiseshop.db.BaseTimeEntity;
+import cholog.wiseshop.db.address.Address;
 import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.product.Product;
 import jakarta.persistence.Entity;
@@ -21,6 +22,8 @@ public class Order extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private int count;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", unique = false)
     private Product product;
@@ -29,21 +32,23 @@ public class Order extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    private int count;
+    @OneToOne
+    @JoinColumn(name = "shipping_address_id")
+    private Address shippingAddress;
 
     public Order() {
     }
 
-    public Order(Product product,
-                 int count,
-                 Member member) {
+    public Order(
+        int count,
+        Product product,
+        Member member,
+        Address shippingAddress
+    ) {
+        this.count = count;
         this.product = product;
-        this.count = count;
         this.member = member;
-    }
-
-    public void updateCount(int count) {
-        this.count = count;
+        this.shippingAddress = shippingAddress;
     }
 
     public Long getId() {
@@ -56,5 +61,13 @@ public class Order extends BaseTimeEntity {
 
     public int getCount() {
         return count;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public Address getShippingAddress() {
+        return shippingAddress;
     }
 }

--- a/src/main/java/cholog/wiseshop/db/order/OrderRepository.java
+++ b/src/main/java/cholog/wiseshop/db/order/OrderRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
     List<Order> findByMemberId(Long memberId);
-    List<Order> findByAddressId(Long shippingAddressId);
+    List<Order> findByAddressIdAndMemberId(Long shippingAddressId, Long memberId);
 }

--- a/src/main/java/cholog/wiseshop/db/order/OrderRepository.java
+++ b/src/main/java/cholog/wiseshop/db/order/OrderRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
     List<Order> findByMemberId(Long memberId);
+    List<Order> findByAddressId(Long shippingAddressId);
 }

--- a/src/main/java/cholog/wiseshop/db/product/Product.java
+++ b/src/main/java/cholog/wiseshop/db/product/Product.java
@@ -28,11 +28,11 @@ public class Product {
     private int price;
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "CAMPAIGN_ID")
+    @JoinColumn(name = "campaign_id")
     private Campaign campaign;
 
     @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
-    @JoinColumn(name = "STOCK_ID")
+    @JoinColumn(name = "stock_id")
     private Stock stock;
 
     public Product(String name,

--- a/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
+++ b/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
@@ -6,6 +6,8 @@ public enum WiseShopErrorCode {
     MEMBER_ID_NOT_FOUND("올바르지 않은 아이디 입니다."),
     MEMBER_SESSION_NOT_EXIST("올바르지 않은 접근입니다."),
     MEMBER_INPROGRESS_CAMPAIGN_EXIST("회원의 진행 중인 캠페인이 존재합니다."),
+    ADDRESS_NOT_FOUND("회원의 배송지 정보가 존재하지 않습니다."),
+    ADDRESS_EXIST_INTO_ORDER("주문 중인 상품에 등록된 배송 정보가 존재합니다."),
     PRODUCT_NOT_FOUND("상품이 존재하지 않습니다."),
     MODIFY_NAME_DESCRIPTION_PRODUCT_NOT_FOUND("이름 및 설명글 수정할 상품이 존재하지 않습니다."),
     MODIFY_PRICE_PRODUCT_NOT_FOUND("가격 수정할 상품이 존재하지 않습니다."),

--- a/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
+++ b/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
@@ -7,6 +7,7 @@ public enum WiseShopErrorCode {
     MEMBER_SESSION_NOT_EXIST("올바르지 않은 접근입니다."),
     MEMBER_INPROGRESS_CAMPAIGN_EXIST("회원의 진행 중인 캠페인이 존재합니다."),
     ADDRESS_NOT_FOUND("회원의 배송지 정보가 존재하지 않습니다."),
+    ADDRESS_OWNER_MISMATCH("배송지 정보가 해당 회원의 것과 일치하지 않습니다."),
     ADDRESS_EXIST_INTO_ORDER("주문 중인 상품에 등록된 배송 정보가 존재합니다."),
     PRODUCT_NOT_FOUND("상품이 존재하지 않습니다."),
     MODIFY_NAME_DESCRIPTION_PRODUCT_NOT_FOUND("이름 및 설명글 수정할 상품이 존재하지 않습니다."),

--- a/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
+++ b/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
@@ -5,6 +5,7 @@ public enum WiseShopErrorCode {
     ALREADY_EXIST_MEMBER("이미 존재하는 회원입니다."),
     MEMBER_ID_NOT_FOUND("올바르지 않은 아이디 입니다."),
     MEMBER_SESSION_NOT_EXIST("올바르지 않은 접근입니다."),
+    MEMBER_INPROGRESS_CAMPAIGN_EXIST("회원의 진행 중인 캠페인이 존재합니다."),
     PRODUCT_NOT_FOUND("상품이 존재하지 않습니다."),
     MODIFY_NAME_DESCRIPTION_PRODUCT_NOT_FOUND("이름 및 설명글 수정할 상품이 존재하지 않습니다."),
     MODIFY_PRICE_PRODUCT_NOT_FOUND("가격 수정할 상품이 존재하지 않습니다."),


### PR DESCRIPTION
### 요약

**기능구현**
- 사용자는 배송지 정보를 여러개 등록할 수 있다.
- 사용자는 배송지 정보를 삭제할 수 있다.
- 사용자는 서비스를 탈퇴할 수 있다.

**고민**
- 정책 중 **"단, 진행 중인 주문이 있는 경우 삭제할 수 없다."**에 대해서 진행 중인 주문을 구분하기 위한 상태가 없기 때문에 단순히 주문 정보가 있을 경우 삭제가 불가능한 형태로 밖에 진행이 안됩니다..
- 이에 대해서 의논이 필요해요!

> 💡테스트는 별도의 이슈를 파서 진행하려고 합니다.