### PR TITLE
feat: 캠페인 상세 기능을 추가 구현한다.

### DIFF
--- a/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
@@ -43,7 +43,7 @@ public class CampaignController {
 
     @GetMapping("/campaigns")
     public ResponseEntity<AllCampaignResponse> readAllCampaign() {
-        List<ReadCampaignResponse> response = campaignService.readAllCampaign();
+        List<ReadCampaignResponse> response = campaignService.readInProgressCampaign();
         return ResponseEntity.status(HttpStatus.OK).body(new AllCampaignResponse(response));
     }
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/dto/response/ReadCampaignResponse.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/dto/response/ReadCampaignResponse.java
@@ -4,11 +4,13 @@ import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.product.Product;
 
-public record ReadCampaignResponse(Long campaignId,
-                                   String startDate,
-                                   String endDate,
-                                   int goalQuantity,
-                                   ProductResponse product) {
+public record ReadCampaignResponse(
+    Long campaignId,
+    String startDate,
+    String endDate,
+    int goalQuantity,
+    ProductResponse product
+) {
 
     public static ReadCampaignResponse of(Product product, Campaign campaign) {
         return new ReadCampaignResponse(

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -8,6 +8,7 @@ import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.common.ThreadTaskScheduler;
 import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.campaign.CampaignRepository;
+import cholog.wiseshop.db.campaign.CampaignState;
 import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
@@ -86,10 +87,12 @@ public class CampaignService {
         );
     }
 
-    public List<ReadCampaignResponse> readAllCampaign() {
-        List<Product> products = productRepository.findAll();
-        return products.stream()
-            .map(product -> ReadCampaignResponse.of(product, product.getCampaign()))
-            .toList();
+    public List<ReadCampaignResponse> readInProgressCampaign() {
+        List<Campaign> campaigns = campaignRepository.findAllByState(CampaignState.IN_PROGRESS);
+        return campaigns.stream()
+            .map(campaign -> {
+                Product product = productRepository.findAllByCampaign(campaign).getFirst();
+                return ReadCampaignResponse.of(product, campaign);
+            }).toList();
     }
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -45,6 +45,7 @@ public class CampaignService {
         LocalDateTime now
     ) {
         CreateProductRequest productAtCampaignRequest = campaignRequest.productRequest();
+        validateQuantity(productAtCampaignRequest.totalQuantity(), campaignRequest.goalQuantity());
         Stock stock = stockRepository.save(new Stock(productAtCampaignRequest.totalQuantity()));
         Campaign campaign = campaignRepository.save(new Campaign(
             campaignRequest.startDate(),
@@ -62,6 +63,12 @@ public class CampaignService {
         ));
         scheduler.scheduleCampaign(campaign);
         return CreateCampaignResponse.from(campaign.getId());
+    }
+
+    private void validateQuantity(int totalQuantity, int goalQuantity) {
+        if (totalQuantity <= goalQuantity) {
+            throw new WiseShopException(WiseShopErrorCode.INVALID_QUANTITY);
+        }
     }
 
     public ReadCampaignResponse readCampaign(Long campaignId) {

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -62,7 +62,8 @@ public class CampaignService {
             campaign,
             stock
         ));
-        scheduler.scheduleCampaign(campaign);
+        scheduler.scheduleCampaignToStart(campaign);
+        scheduler.scheduleCampaignToFinish(campaign);
         return CreateCampaignResponse.from(campaign.getId());
     }
 

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -69,7 +69,7 @@ public class CampaignService {
 
     private void validateQuantity(int totalQuantity, int goalQuantity) {
         if (totalQuantity <= goalQuantity) {
-            throw new WiseShopException(WiseShopErrorCode.INVALID_QUANTITY);
+            throw new WiseShopException(WiseShopErrorCode.INVALID_GOAL_QUANTITY);
         }
     }
 

--- a/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
+++ b/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
@@ -37,11 +37,11 @@ public class ProductController {
     }
 
     @PatchMapping("/products/{id}/price")
-    public ResponseEntity<Void> modifyProductPrice(
+    public ResponseEntity<Void> modifyProductPriceAndStock(
         @PathVariable Long id,
         @RequestBody ModifyProductPriceRequest request
     ) {
-        productService.modifyProductPrice(id, request);
+        productService.modifyProductPriceAndStock(id, request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
+++ b/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
@@ -1,6 +1,6 @@
 package cholog.wiseshop.api.product.controller;
 
-import cholog.wiseshop.api.product.dto.request.ModifyProductPriceRequest;
+import cholog.wiseshop.api.product.dto.request.ModifyProductPriceAntStockRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.api.product.service.ProductService;
@@ -40,7 +40,7 @@ public class ProductController {
     @PatchMapping("/products/{id}/price")
     public ResponseEntity<Void> modifyProductPriceAndStock(
         @PathVariable Long id,
-        @RequestBody ModifyProductPriceRequest request
+        @RequestBody ModifyProductPriceAntStockRequest request
     ) {
         productService.modifyProductPriceAndStock(id, request);
         return ResponseEntity.ok().build();

--- a/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
+++ b/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
@@ -26,7 +26,8 @@ public class ProductController {
 
     @GetMapping("/products/{id}")
     public ResponseEntity<ProductResponse> getProduct(@PathVariable Long id) {
-        return ResponseEntity.status(HttpStatus.OK).body(productService.getProduct(id));
+        ProductResponse response = productService.getProduct(id);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
     @PatchMapping("/products/{id}")

--- a/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
+++ b/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
@@ -1,6 +1,6 @@
 package cholog.wiseshop.api.product.controller;
 
-import cholog.wiseshop.api.product.dto.request.ModifyProductPriceAntStockRequest;
+import cholog.wiseshop.api.product.dto.request.ModifyProductPriceAndStockRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.api.product.service.ProductService;
@@ -40,7 +40,7 @@ public class ProductController {
     @PatchMapping("/products/{id}/price")
     public ResponseEntity<Void> modifyProductPriceAndStock(
         @PathVariable Long id,
-        @RequestBody ModifyProductPriceAntStockRequest request
+        @RequestBody ModifyProductPriceAndStockRequest request
     ) {
         productService.modifyProductPriceAndStock(id, request);
         return ResponseEntity.ok().build();

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductPriceAndStockRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductPriceAndStockRequest.java
@@ -1,6 +1,6 @@
 package cholog.wiseshop.api.product.dto.request;
 
-public record ModifyProductPriceAntStockRequest(
+public record ModifyProductPriceAndStockRequest(
     int price,
     int totalQuantity
 ) {

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductPriceAntStockRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductPriceAntStockRequest.java
@@ -1,6 +1,6 @@
 package cholog.wiseshop.api.product.dto.request;
 
-public record ModifyProductPriceRequest(
+public record ModifyProductPriceAntStockRequest(
     int price,
     int totalQuantity
 ) {

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductPriceRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductPriceRequest.java
@@ -1,5 +1,8 @@
 package cholog.wiseshop.api.product.dto.request;
 
-public record ModifyProductPriceRequest(int price) {
+public record ModifyProductPriceRequest(
+    int price,
+    int totalQuantity
+) {
 
 }

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductRequest.java
@@ -1,5 +1,8 @@
 package cholog.wiseshop.api.product.dto.request;
 
-public record ModifyProductRequest(String name, String description) {
+public record ModifyProductRequest(
+    String name,
+    String description
+) {
 
 }

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyQuantityRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyQuantityRequest.java
@@ -1,7 +1,9 @@
 package cholog.wiseshop.api.product.dto.request;
 
-public record ModifyQuantityRequest(Long campaignId,
-                                    Long productId,
-                                    Integer modifyQuantity) {
+public record ModifyQuantityRequest(
+    Long campaignId,
+    Long productId,
+    Integer modifyQuantity
+) {
 
 }

--- a/src/main/java/cholog/wiseshop/api/product/dto/response/ProductResponse.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/response/ProductResponse.java
@@ -2,11 +2,13 @@ package cholog.wiseshop.api.product.dto.response;
 
 import cholog.wiseshop.db.product.Product;
 
-public record ProductResponse(Long id,
-                              String name,
-                              String description,
-                              Integer price,
-                              Integer totalQuantity) {
+public record ProductResponse(
+    Long id,
+    String name,
+    String description,
+    Integer price,
+    Integer totalQuantity
+) {
 
     public ProductResponse(Product product) {
         this(

--- a/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
+++ b/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
@@ -26,19 +26,6 @@ public class ProductService {
         this.campaignRepository = campaignRepository;
     }
 
-    // TODO: 안쓰면 제거
-    public Long createProduct(CreateProductRequest request) {
-        Stock stock = new Stock(request.totalQuantity());
-        Product product = Product.builder()
-            .name(request.name())
-            .description(request.description())
-            .price(request.price())
-            .stock(stock)
-            .build();
-        Product createdProduct = productRepository.save(product);
-        return createdProduct.getId();
-    }
-
     @Transactional(readOnly = true)
     public ProductResponse getProduct(Long id) {
         return new ProductResponse(productRepository.findById(id)

--- a/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
+++ b/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
@@ -49,11 +49,11 @@ public class ProductService {
         productRepository.save(existedProduct);
     }
 
-    public void modifyProductPrice(Long productId, ModifyProductPriceRequest request) {
+    public void modifyProductPriceAndStock(Long productId, ModifyProductPriceRequest request) {
         Product existedProduct = productRepository.findById(productId)
             .orElseThrow(
                 () -> new WiseShopException(WiseShopErrorCode.MODIFY_PRICE_PRODUCT_NOT_FOUND));
-        existedProduct.modifyPrice(request.price());
+        existedProduct.modifyPriceAndStock(request.price(), request.totalQuantity());
         productRepository.save(existedProduct);
     }
 

--- a/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
+++ b/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
@@ -58,8 +58,11 @@ public class ProductService {
     }
 
     public void deleteProduct(Long id) {
-        productRepository.findById(id)
+        Product product = productRepository.findById(id)
             .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.PRODUCT_NOT_FOUND));
+        if (product.getCampaign().isNotWaiting()) {
+            throw new WiseShopException(WiseShopErrorCode.INVALID_CAMPAIGN_DELETE_STATE);
+        }
         productRepository.deleteById(id);
     }
 }

--- a/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
+++ b/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
@@ -1,7 +1,7 @@
 package cholog.wiseshop.api.product.service;
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest.CreateProductRequest;
-import cholog.wiseshop.api.product.dto.request.ModifyProductPriceAntStockRequest;
+import cholog.wiseshop.api.product.dto.request.ModifyProductPriceAndStockRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.db.campaign.Campaign;
@@ -53,10 +53,9 @@ public class ProductService {
         productRepository.save(existedProduct);
     }
 
-    public void modifyProductPriceAndStock(Long productId, ModifyProductPriceAntStockRequest request) {
+    public void modifyProductPriceAndStock(Long productId, ModifyProductPriceAndStockRequest request) {
         Product existedProduct = productRepository.findById(productId)
-            .orElseThrow(
-                () -> new WiseShopException(WiseShopErrorCode.MODIFY_PRICE_PRODUCT_NOT_FOUND));
+            .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.MODIFY_PRICE_PRODUCT_NOT_FOUND));
         existedProduct.modifyPriceAndStock(request.price(), request.totalQuantity());
         productRepository.save(existedProduct);
     }

--- a/src/main/java/cholog/wiseshop/common/ScheduleRegister.java
+++ b/src/main/java/cholog/wiseshop/common/ScheduleRegister.java
@@ -1,0 +1,33 @@
+package cholog.wiseshop.common;
+
+import cholog.wiseshop.db.campaign.Campaign;
+import cholog.wiseshop.db.campaign.CampaignRepository;
+import cholog.wiseshop.db.campaign.CampaignState;
+import jakarta.annotation.PostConstruct;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ScheduleRegister {
+
+
+    private final CampaignRepository campaignRepository;
+    private final ThreadTaskScheduler scheduler;
+
+    public ScheduleRegister(CampaignRepository campaignRepository, ThreadTaskScheduler scheduler) {
+        this.campaignRepository = campaignRepository;
+        this.scheduler = scheduler;
+    }
+
+    @PostConstruct
+    private void postConstructCampaigns() {
+        List<Campaign> campaigns = campaignRepository.findAllByStates(
+            List.of(CampaignState.WAITING, CampaignState.IN_PROGRESS));
+        for (Campaign campaign : campaigns) {
+            if (campaign.getState().equals(CampaignState.WAITING)) {
+                scheduler.scheduleCampaignToStart(campaign);
+            }
+            scheduler.scheduleCampaignToFinish(campaign);
+        }
+    }
+}

--- a/src/main/java/cholog/wiseshop/common/ScheduleRegister.java
+++ b/src/main/java/cholog/wiseshop/common/ScheduleRegister.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class ScheduleRegister {
 
-
     private final CampaignRepository campaignRepository;
     private final ThreadTaskScheduler scheduler;
 

--- a/src/main/java/cholog/wiseshop/common/ThreadTaskScheduler.java
+++ b/src/main/java/cholog/wiseshop/common/ThreadTaskScheduler.java
@@ -1,10 +1,6 @@
 package cholog.wiseshop.common;
 
 import cholog.wiseshop.db.campaign.Campaign;
-import cholog.wiseshop.db.campaign.CampaignRepository;
-import cholog.wiseshop.db.campaign.CampaignState;
-import cholog.wiseshop.exception.WiseShopErrorCode;
-import cholog.wiseshop.exception.WiseShopException;
 import java.time.ZoneId;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Component;
@@ -16,35 +12,26 @@ public class ThreadTaskScheduler {
 
     private final ThreadPoolTaskScheduler scheduler;
     private final TransactionTemplate transactionTemplate;
-    private final CampaignRepository campaignRepository;
 
     public ThreadTaskScheduler(
         ThreadPoolTaskScheduler scheduler,
-        PlatformTransactionManager transactionManager,
-        CampaignRepository campaignRepository
+        PlatformTransactionManager transactionManager
     ) {
         this.scheduler = scheduler;
         this.transactionTemplate = new TransactionTemplate(transactionManager);
-        this.campaignRepository = campaignRepository;
     }
 
     public void scheduleCampaign(Campaign campaign) {
         Runnable startCampaign = () -> transactionTemplate.execute(status -> {
-            changeCampaignState(campaign.getId(), CampaignState.IN_PROGRESS);
+            campaign.setState(campaign.getStartDate(), campaign.getEndDate());
             return null;
         });
         scheduler.schedule(startCampaign, campaign.getStartDate().atZone(ZoneId.systemDefault()).toInstant());
 
         Runnable endCampaign = () -> transactionTemplate.execute(status -> {
-            changeCampaignState(campaign.getId(), CampaignState.FAILED);
+            campaign.setStateWhenFinish();
             return null;
         });
         scheduler.schedule(endCampaign, campaign.getEndDate().atZone(ZoneId.systemDefault()).toInstant());
-    }
-
-    private void changeCampaignState(Long campaignId, CampaignState state) {
-        Campaign campaign = campaignRepository.findById(campaignId)
-            .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.CAMPAIGN_NOT_FOUND));
-        campaign.updateState(state);
     }
 }

--- a/src/main/java/cholog/wiseshop/common/ThreadTaskScheduler.java
+++ b/src/main/java/cholog/wiseshop/common/ThreadTaskScheduler.java
@@ -21,13 +21,15 @@ public class ThreadTaskScheduler {
         this.transactionTemplate = new TransactionTemplate(transactionManager);
     }
 
-    public void scheduleCampaign(Campaign campaign) {
+    public void scheduleCampaignToStart(Campaign campaign) {
         Runnable startCampaign = () -> transactionTemplate.execute(status -> {
             campaign.setState(campaign.getStartDate(), campaign.getEndDate());
             return null;
         });
         scheduler.schedule(startCampaign, campaign.getStartDate().atZone(ZoneId.systemDefault()).toInstant());
+    }
 
+    public void scheduleCampaignToFinish(Campaign campaign) {
         Runnable endCampaign = () -> transactionTemplate.execute(status -> {
             campaign.setStateWhenFinish();
             return null;

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -84,6 +84,14 @@ public class Campaign {
         return CampaignState.WAITING;
     }
 
+    public void setStateWhenFinish() {
+        if (soldQuantity < goalQuantity) {
+            state = CampaignState.FAILED;
+        } else {
+            state = CampaignState.SUCCESS;
+        }
+    }
+
     public static CampaignBuilder builder() {
         return new CampaignBuilder();
     }

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -77,7 +77,7 @@ public class Campaign {
         if (endDate.isBefore(now)) {
             throw new WiseShopException(WiseShopErrorCode.CAMPAIGN_INVALID_DATE_RANGE);
         }
-        if (startDate.isBefore(now) && now.isBefore(endDate)) {
+        if (startDate.isBefore(now) && endDate.isAfter(now)) {
             state = CampaignState.IN_PROGRESS;
         } else {
             state = CampaignState.WAITING;

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -194,4 +194,8 @@ public class Campaign {
     public boolean isInProgress() {
         return CampaignState.IN_PROGRESS.equals(state);
     }
+
+    public boolean isNotWaiting() {
+        return !CampaignState.WAITING.equals(state);
+    }
 }

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -195,7 +195,11 @@ public class Campaign {
         return CampaignState.IN_PROGRESS.equals(state);
     }
 
+    public boolean isWaiting() {
+        return CampaignState.WAITING.equals(state);
+    }
+
     public boolean isNotWaiting() {
-        return !CampaignState.WAITING.equals(state);
+        return !isWaiting();
     }
 }

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -55,7 +55,7 @@ public class Campaign {
         this.startDate = startDate;
         this.endDate = endDate;
         this.goalQuantity = goalQuantity;
-        this.state = setState(startDate, endDate);
+        setState(startDate, endDate);
         this.member = member;
     }
 
@@ -72,16 +72,16 @@ public class Campaign {
         }
     }
 
-    // TODO: 상태 변경 테스트
-    public CampaignState setState(LocalDateTime startDate, LocalDateTime endDate) {
+    public void setState(LocalDateTime startDate, LocalDateTime endDate) {
         LocalDateTime now = LocalDateTime.now();
         if (endDate.isBefore(now)) {
             throw new WiseShopException(WiseShopErrorCode.CAMPAIGN_INVALID_DATE_RANGE);
         }
         if (startDate.isBefore(now) && now.isBefore(endDate)) {
-            return CampaignState.IN_PROGRESS;
+            state = CampaignState.IN_PROGRESS;
+        } else {
+            state = CampaignState.WAITING;
         }
-        return CampaignState.WAITING;
     }
 
     public void setStateWhenFinish() {

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -51,12 +51,11 @@ public class Campaign {
         LocalDateTime now
     ) {
         validateStartDate(startDate, now);
+        validateDuration(startDate, endDate);
         this.startDate = startDate;
         this.endDate = endDate;
         this.goalQuantity = goalQuantity;
-        this.state = CampaignState.WAITING;
-        // TODO : 현재 시간과 비교하여 state를 유동적으로 변경할 수 있게 하면 어떨지..
-        // ex) endDate < now 이면 생성될 수 없고, startDate <= now && now <= endDate 이면 IN_PROGRESS로 생성된다.
+        this.state = setState(startDate, endDate);
         this.member = member;
     }
 
@@ -65,6 +64,24 @@ public class Campaign {
         if (duration.toHours() > 24) {
             throw new WiseShopException(WiseShopErrorCode.CAMPAIGN_INVALID_START_DATE);
         }
+    }
+
+    private void validateDuration(LocalDateTime startDate, LocalDateTime endDate) {
+        if (startDate.isAfter(endDate)) {
+            throw new WiseShopException(WiseShopErrorCode.CAMPAIGN_INVALID_DATE_RANGE);
+        }
+    }
+
+    // TODO: 상태 변경 테스트
+    public CampaignState setState(LocalDateTime startDate, LocalDateTime endDate) {
+        LocalDateTime now = LocalDateTime.now();
+        if (endDate.isBefore(now)) {
+            throw new WiseShopException(WiseShopErrorCode.CAMPAIGN_INVALID_DATE_RANGE);
+        }
+        if (startDate.isBefore(now) && now.isBefore(endDate)) {
+            return CampaignState.IN_PROGRESS;
+        }
+        return CampaignState.WAITING;
     }
 
     public static CampaignBuilder builder() {

--- a/src/main/java/cholog/wiseshop/db/campaign/CampaignRepository.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/CampaignRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface CampaignRepository extends JpaRepository<Campaign, Long> {
 
 	List<Campaign> findCampaignByMemberId(Long memberId);
+
+    List<Campaign> findAllByState(CampaignState state);
 }

--- a/src/main/java/cholog/wiseshop/db/campaign/CampaignRepository.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/CampaignRepository.java
@@ -2,10 +2,14 @@ package cholog.wiseshop.db.campaign;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CampaignRepository extends JpaRepository<Campaign, Long> {
 
-	List<Campaign> findCampaignByMemberId(Long memberId);
+    List<Campaign> findCampaignByMemberId(Long memberId);
 
-    List<Campaign> findAllByState(CampaignState state);
+    @Query("SELECT c FROM Campaign c WHERE c.state IN :states")
+    List<Campaign> findAllByStates(List<CampaignState> states);
+
+    List<Campaign> findAllByState(CampaignState campaignState);
 }

--- a/src/main/java/cholog/wiseshop/db/product/Product.java
+++ b/src/main/java/cholog/wiseshop/db/product/Product.java
@@ -2,6 +2,8 @@ package cholog.wiseshop.db.product;
 
 import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.stock.Stock;
+import cholog.wiseshop.exception.WiseShopErrorCode;
+import cholog.wiseshop.exception.WiseShopException;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -99,8 +101,15 @@ public class Product {
         this.campaign = campaign;
     }
 
-    public void modifyPrice(int price) {
+    public void modifyPriceAndStock(int price, int totalQuantity) {
+        if (campaign.isInProgress()) {
+            throw new WiseShopException(WiseShopErrorCode.CAMPAIGN_ALREADY_IN_PROGRESS);
+        }
+        if (totalQuantity <= campaign.getGoalQuantity()) {
+            throw new WiseShopException(WiseShopErrorCode.INVALID_TOTAL_QUANTITY);
+        }
         this.price = price;
+        this.stock.modifyTotalQuantity(totalQuantity);
     }
 
     public Long getId() {

--- a/src/main/java/cholog/wiseshop/db/product/ProductRepository.java
+++ b/src/main/java/cholog/wiseshop/db/product/ProductRepository.java
@@ -1,5 +1,6 @@
 package cholog.wiseshop.db.product;
 
+import cholog.wiseshop.db.campaign.Campaign;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -9,4 +10,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     @Query("SELECT p FROM Product p JOIN FETCH p.stock JOIN FETCH p.campaign WHERE p.campaign.id = :campaignId")
     List<Product> findProductsByCampaignId(@Param("campaignId") Long campaignId);
+
+    List<Product> findAllByCampaign(Campaign campaign);
 }

--- a/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
+++ b/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
@@ -22,7 +22,8 @@ public enum WiseShopErrorCode {
     ORDER_NOT_AVAILABLE("자신이 만든 캠페인은 주문이 불가능합니다."),
     CAMPAIGN_INVALID_DATE_RANGE("잘못된 캠페인 날짜입니다."),
     INVALID_GOAL_QUANTITY("목표수량은 재고보다 적어야 합니다."),
-    INVALID_TOTAL_QUANTITY("재고는 목표수량보다 많아야 합니다.");
+    INVALID_TOTAL_QUANTITY("재고는 목표수량보다 많아야 합니다."),
+    INVALID_CAMPAIGN_DELETE_STATE("판매 대기 중이 아닌 상품은 삭제할 수 없습니다.");
 
     private String message;
 

--- a/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
+++ b/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
@@ -21,7 +21,7 @@ public enum WiseShopErrorCode {
     ORDER_NOT_FOUND("주문 정보가 존재하지 않습니다."),
     ORDER_NOT_AVAILABLE("자신이 만든 캠페인은 주문이 불가능합니다."),
     CAMPAIGN_INVALID_DATE_RANGE("잘못된 캠페인 날짜입니다."),
-    INVALID_QUANTITY("목표수량은 재고보다 적어야 합니다.");
+    INVALID_GOAL_QUANTITY("목표수량은 재고보다 적어야 합니다.");
 
     private String message;
 

--- a/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
+++ b/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
@@ -21,7 +21,8 @@ public enum WiseShopErrorCode {
     ORDER_NOT_FOUND("주문 정보가 존재하지 않습니다."),
     ORDER_NOT_AVAILABLE("자신이 만든 캠페인은 주문이 불가능합니다."),
     CAMPAIGN_INVALID_DATE_RANGE("잘못된 캠페인 날짜입니다."),
-    INVALID_GOAL_QUANTITY("목표수량은 재고보다 적어야 합니다.");
+    INVALID_GOAL_QUANTITY("목표수량은 재고보다 적어야 합니다."),
+    INVALID_TOTAL_QUANTITY("재고는 목표수량보다 많아야 합니다.");
 
     private String message;
 

--- a/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
+++ b/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
@@ -20,7 +20,8 @@ public enum WiseShopErrorCode {
     STOCK_NOT_AVAILABLE("재고 수량은 최소 1개 이상이어야 합니다."),
     ORDER_NOT_FOUND("주문 정보가 존재하지 않습니다."),
     ORDER_NOT_AVAILABLE("자신이 만든 캠페인은 주문이 불가능합니다."),
-    CAMPAIGN_INVALID_DATE_RANGE("잘못된 캠페인 날짜입니다.");
+    CAMPAIGN_INVALID_DATE_RANGE("잘못된 캠페인 날짜입니다."),
+    INVALID_QUANTITY("목표수량은 재고보다 적어야 합니다.");
 
     private String message;
 

--- a/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
+++ b/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
@@ -19,8 +19,8 @@ public enum WiseShopErrorCode {
     CAMPAIGN_INVALID_START_DATE("캠페인의 시작 날짜는 현재로부터 24시간을 넘을 수 없습니다."),
     STOCK_NOT_AVAILABLE("재고 수량은 최소 1개 이상이어야 합니다."),
     ORDER_NOT_FOUND("주문 정보가 존재하지 않습니다."),
-    ORDER_NOT_AVAILABLE("자신이 만든 캠페인은 주문이 불가능합니다.")
-    ;
+    ORDER_NOT_AVAILABLE("자신이 만든 캠페인은 주문이 불가능합니다."),
+    CAMPAIGN_INVALID_DATE_RANGE("잘못된 캠페인 날짜입니다.");
 
     private String message;
 

--- a/src/test/java/cholog/wiseshop/domain/ProductServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/ProductServiceTest.java
@@ -3,7 +3,7 @@ package cholog.wiseshop.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import cholog.wiseshop.api.product.dto.request.ModifyProductPriceAntStockRequest;
+import cholog.wiseshop.api.product.dto.request.ModifyProductPriceAndStockRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
 import cholog.wiseshop.api.product.service.ProductService;
 import cholog.wiseshop.common.BaseTest;
@@ -76,7 +76,7 @@ class ProductServiceTest extends BaseTest {
             Stock stock = new Stock(20);
             stockRepository.save(stock);
             Product product = productRepository.save(ProductFixture.재고가_설정된_캠페인의_보약(campaign, stock));
-            ModifyProductPriceAntStockRequest request = new ModifyProductPriceAntStockRequest(
+            ModifyProductPriceAndStockRequest request = new ModifyProductPriceAndStockRequest(
                 2000,
                 30
             );
@@ -98,7 +98,7 @@ class ProductServiceTest extends BaseTest {
             Stock stock = new Stock(20);
             stockRepository.save(stock);
             Product product = productRepository.save(ProductFixture.재고가_설정된_캠페인의_보약(campaign, stock));
-            ModifyProductPriceAntStockRequest request = new ModifyProductPriceAntStockRequest(
+            ModifyProductPriceAndStockRequest request = new ModifyProductPriceAndStockRequest(
                 2000,
                 30
             );
@@ -117,7 +117,7 @@ class ProductServiceTest extends BaseTest {
             Stock stock = new Stock(20);
             stockRepository.save(stock);
             Product product = productRepository.save(ProductFixture.재고가_설정된_캠페인의_보약(campaign, stock));
-            ModifyProductPriceAntStockRequest request = new ModifyProductPriceAntStockRequest(
+            ModifyProductPriceAndStockRequest request = new ModifyProductPriceAndStockRequest(
                 2000,
                 1
             );
@@ -126,7 +126,6 @@ class ProductServiceTest extends BaseTest {
             assertThatThrownBy(() -> productService.modifyProductPriceAndStock(product.getId(), request))
                 .isInstanceOf(WiseShopException.class)
                 .hasMessage(WiseShopErrorCode.INVALID_TOTAL_QUANTITY.getMessage());
-
         }
     }
 

--- a/src/test/java/cholog/wiseshop/domain/ProductServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/ProductServiceTest.java
@@ -1,12 +1,24 @@
 package cholog.wiseshop.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import cholog.wiseshop.api.product.dto.request.ModifyProductPriceAntStockRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
 import cholog.wiseshop.api.product.service.ProductService;
 import cholog.wiseshop.common.BaseTest;
+import cholog.wiseshop.db.campaign.Campaign;
+import cholog.wiseshop.db.campaign.CampaignRepository;
+import cholog.wiseshop.db.member.Member;
+import cholog.wiseshop.db.member.MemberRepository;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
+import cholog.wiseshop.db.stock.Stock;
+import cholog.wiseshop.db.stock.StockRepository;
+import cholog.wiseshop.exception.WiseShopErrorCode;
+import cholog.wiseshop.exception.WiseShopException;
+import cholog.wiseshop.fixture.CampaignFixture;
+import cholog.wiseshop.fixture.MemberFixture;
 import cholog.wiseshop.fixture.ProductFixture;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Nested;
@@ -21,6 +33,15 @@ class ProductServiceTest extends BaseTest {
 
     @Autowired
     private ProductRepository productRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CampaignRepository campaignRepository;
+
+    @Autowired
+    private StockRepository stockRepository;
 
     @Nested
     class 상품_정보를_수정한다 {
@@ -45,6 +66,99 @@ class ProductServiceTest extends BaseTest {
                     assertThat(modified.getDescription()).isEqualTo("수정된 보약 설명");
                 }
             );
+        }
+
+        @Test
+        void 상품의_가격과_재고를_정상적으로_수정한다() {
+            // given
+            Member member = memberRepository.save(MemberFixture.최준호());
+            Campaign campaign = campaignRepository.save(CampaignFixture.대기중인_보약_캠페인(member));
+            Stock stock = new Stock(20);
+            stockRepository.save(stock);
+            Product product = productRepository.save(ProductFixture.재고가_설정된_캠페인의_보약(campaign, stock));
+            ModifyProductPriceAntStockRequest request = new ModifyProductPriceAntStockRequest(
+                2000,
+                30
+            );
+
+            // when
+            productService.modifyProductPriceAndStock(product.getId(), request);
+
+            // then
+            Product modified = productRepository.findById(product.getId()).get();
+            assertThat(modified.getPrice()).isEqualTo(2000);
+            assertThat(modified.getStock().getTotalQuantity()).isEqualTo(30);
+        }
+
+        @Test
+        void 캠페인이_진행중일_경우_상품가격과_재고를_수정할_수_없다() {
+            // given
+            Member member = memberRepository.save(MemberFixture.최준호());
+            Campaign campaign = campaignRepository.save(CampaignFixture.진행중인_보약_캠페인(member));
+            Stock stock = new Stock(20);
+            stockRepository.save(stock);
+            Product product = productRepository.save(ProductFixture.재고가_설정된_캠페인의_보약(campaign, stock));
+            ModifyProductPriceAntStockRequest request = new ModifyProductPriceAntStockRequest(
+                2000,
+                30
+            );
+
+            // when & then
+            assertThatThrownBy(() -> productService.modifyProductPriceAndStock(product.getId(), request))
+                .isInstanceOf(WiseShopException.class)
+                .hasMessage(WiseShopErrorCode.CAMPAIGN_ALREADY_IN_PROGRESS.getMessage());
+        }
+
+        @Test
+        void 재고를_목표수량보다_적게_수정할_수_없다() {
+            // given
+            Member member = memberRepository.save(MemberFixture.최준호());
+            Campaign campaign = campaignRepository.save(CampaignFixture.대기중인_보약_캠페인(member));
+            Stock stock = new Stock(20);
+            stockRepository.save(stock);
+            Product product = productRepository.save(ProductFixture.재고가_설정된_캠페인의_보약(campaign, stock));
+            ModifyProductPriceAntStockRequest request = new ModifyProductPriceAntStockRequest(
+                2000,
+                1
+            );
+
+            // when & then
+            assertThatThrownBy(() -> productService.modifyProductPriceAndStock(product.getId(), request))
+                .isInstanceOf(WiseShopException.class)
+                .hasMessage(WiseShopErrorCode.INVALID_TOTAL_QUANTITY.getMessage());
+
+        }
+    }
+
+    @Nested
+    class 상품을_삭제한다 {
+
+        @Test
+        void 상품_하나를_정상적으로_삭제한다() {
+            // given
+            Member member = memberRepository.save(MemberFixture.최준호());
+            Campaign campaign = campaignRepository.save(CampaignFixture.대기중인_보약_캠페인(member));
+            Product product = productRepository.save(ProductFixture.캠페인의_보약(campaign));
+
+            // when
+            productService.deleteProduct(product.getId());
+
+            //then
+            assertThat(productRepository.findById(product.getId())).isEmpty();
+            assertThat(campaignRepository.findById(campaign.getId())).isEmpty();
+        }
+
+        @Test
+        void 캠페인이_진행중이면_상품을_삭제할_수_없다() {
+            // given
+            Member member = memberRepository.save(MemberFixture.최준호());
+            Campaign campaign = campaignRepository.save(CampaignFixture.진행중인_보약_캠페인(member));
+            Product product = productRepository.save(ProductFixture.캠페인의_보약(campaign));
+
+            // when & then
+            assertThatThrownBy(() -> productService.deleteProduct(product.getId()))
+                .isInstanceOf(WiseShopException.class)
+                .hasMessage(WiseShopErrorCode.INVALID_CAMPAIGN_DELETE_STATE.getMessage());
         }
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/member/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/member/CampaignServiceTest.java
@@ -1,16 +1,21 @@
 package cholog.wiseshop.domain.member;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest.CreateProductRequest;
 import cholog.wiseshop.api.campaign.service.CampaignService;
 import cholog.wiseshop.common.BaseTest;
+import cholog.wiseshop.db.campaign.Campaign;
+import cholog.wiseshop.db.campaign.CampaignState;
 import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.member.MemberRepository;
+import cholog.wiseshop.exception.WiseShopErrorCode;
 import cholog.wiseshop.exception.WiseShopException;
 import cholog.wiseshop.fixture.MemberFixture;
 import cholog.wiseshop.fixture.ProductFixture.Request;
 import java.time.LocalDateTime;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,14 +40,128 @@ public class CampaignServiceTest extends BaseTest {
             CreateCampaignRequest request = new CreateCampaignRequest(
                 now.minusHours(25),
                 now.minusHours(23),
-                100,
+                90,
                 Request.보약_생성_요청()
             );
 
             // when & then
-            Assertions.assertThatThrownBy(
-                    () -> campaignService.createCampaign(request, member, now))
-                .isInstanceOf(WiseShopException.class);
+            assertThatThrownBy(
+                () -> campaignService.createCampaign(request, member, now))
+                .isInstanceOf(WiseShopException.class)
+                .hasMessage(WiseShopErrorCode.CAMPAIGN_INVALID_START_DATE.getMessage());
+        }
+
+        @Test
+        void 총_재고가_목표_수량_이하면_예외() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            Member member = memberRepository.save(MemberFixture.최준호());
+            CreateProductRequest productRequest = new CreateProductRequest(
+                "보약",
+                "먹으면 기분이 좋아져요.",
+                10000,
+                100
+            );
+            CreateCampaignRequest campaignRequest = new CreateCampaignRequest(
+                now.plusHours(1),
+                now.plusHours(2),
+                100,
+                productRequest
+            );
+
+            // when & then
+            assertThatThrownBy(
+                () -> campaignService.createCampaign(campaignRequest, member, now))
+                .isInstanceOf(WiseShopException.class)
+                .hasMessage(WiseShopErrorCode.INVALID_QUANTITY.getMessage());
+        }
+
+        @Test
+        void 캠페인_시작날짜가_종료날짜_보다_이후면_예외() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            Member member = memberRepository.save(MemberFixture.최준호());
+            CreateCampaignRequest request = new CreateCampaignRequest(
+                now.plusHours(2),
+                now.plusHours(1),
+                90,
+                Request.보약_생성_요청()
+            );
+
+            // when & then
+            assertThatThrownBy(
+                () -> campaignService.createCampaign(request, member, now))
+                .isInstanceOf(WiseShopException.class)
+                .hasMessage(WiseShopErrorCode.CAMPAIGN_INVALID_DATE_RANGE.getMessage());
+        }
+
+        @Test
+        void 현재_시간이_시작시간_이후_종료시간_이전일_때_상태변경() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            Member member = memberRepository.save(MemberFixture.최준호());
+            LocalDateTime startDate = now.plusHours(1);
+            LocalDateTime endDate = now.plusHours(2);
+            Campaign campaign = new Campaign(startDate, endDate, 90, member, now);
+
+            // when
+            campaign.setState(now.minusHours(1), endDate);
+
+            // then
+            assertThat(campaign.getState()).isEqualTo(CampaignState.IN_PROGRESS);
+        }
+
+        @Test
+        void 현재_시간이_시작시간_이전일_때_상태설정() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            Member member = memberRepository.save(MemberFixture.최준호());
+            LocalDateTime startDate = now.plusHours(1);
+            LocalDateTime endDate = now.plusHours(2);
+
+            // when
+            Campaign campaign = new Campaign(startDate, endDate, 90, member, now);
+
+            // then
+            assertThat(campaign.getState()).isEqualTo(CampaignState.WAITING);
+        }
+
+        @Test
+        void 종료_후_목표수량_미달성_시_상태설정() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            Campaign campaign = Campaign.builder()
+                .startDate(now.plusHours(1))
+                .endDate(now.plusHours(2))
+                .goalQuantity(5)
+                .soldQuantity(2)
+                .now(now)
+                .build();
+
+            // when
+            campaign.setStateWhenFinish();
+
+            // then
+            assertThat(campaign.getState()).isEqualTo(CampaignState.FAILED);
+        }
+
+        @Test
+        void 종료_후_목표수량_달성_시_상태설정(){
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            Campaign campaign = Campaign.builder()
+                .startDate(now.plusHours(1))
+                .endDate(now.plusHours(2))
+                .goalQuantity(5)
+                .soldQuantity(5)
+                .now(now)
+                .build();
+
+            // when
+            campaign.setStateWhenFinish();
+
+            // then
+            assertThat(campaign.getState()).isEqualTo(CampaignState.SUCCESS);
         }
 
         @Test
@@ -63,8 +182,8 @@ public class CampaignServiceTest extends BaseTest {
             );
 
             // when & then
-            Assertions.assertThatThrownBy(
-                    () -> campaignService.createCampaign(request, member, now))
+            assertThatThrownBy(
+                () -> campaignService.createCampaign(request, member, now))
                 .isInstanceOf(WiseShopException.class);
         }
     }

--- a/src/test/java/cholog/wiseshop/domain/member/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/member/CampaignServiceTest.java
@@ -73,7 +73,7 @@ public class CampaignServiceTest extends BaseTest {
             assertThatThrownBy(
                 () -> campaignService.createCampaign(campaignRequest, member, now))
                 .isInstanceOf(WiseShopException.class)
-                .hasMessage(WiseShopErrorCode.INVALID_QUANTITY.getMessage());
+                .hasMessage(WiseShopErrorCode.INVALID_GOAL_QUANTITY.getMessage());
         }
 
         @Test
@@ -185,7 +185,7 @@ public class CampaignServiceTest extends BaseTest {
             assertThatThrownBy(
                 () -> campaignService.createCampaign(request, member, now))
                 .isInstanceOf(WiseShopException.class)
-                .hasMessage(WiseShopErrorCode.INVALID_QUANTITY.getMessage());
+                .hasMessage(WiseShopErrorCode.INVALID_GOAL_QUANTITY.getMessage());
         }
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/member/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/member/CampaignServiceTest.java
@@ -146,7 +146,7 @@ public class CampaignServiceTest extends BaseTest {
         }
 
         @Test
-        void 종료_후_목표수량_달성_시_상태설정(){
+        void 종료_후_목표수량_달성_시_상태설정() {
             // given
             LocalDateTime now = LocalDateTime.now();
             Campaign campaign = Campaign.builder()
@@ -184,7 +184,8 @@ public class CampaignServiceTest extends BaseTest {
             // when & then
             assertThatThrownBy(
                 () -> campaignService.createCampaign(request, member, now))
-                .isInstanceOf(WiseShopException.class);
+                .isInstanceOf(WiseShopException.class)
+                .hasMessage(WiseShopErrorCode.INVALID_QUANTITY.getMessage());
         }
     }
 }

--- a/src/test/java/cholog/wiseshop/fixture/CampaignFixture.java
+++ b/src/test/java/cholog/wiseshop/fixture/CampaignFixture.java
@@ -17,6 +17,20 @@ public class CampaignFixture {
             .goalQuantity(100)
             .soldQuantity(0)
             .member(member)
+            .now(now)
+            .build();
+    }
+
+    public static Campaign 대기중인_보약_캠페인(Member member) {
+        LocalDateTime now = LocalDateTime.now();
+        return Campaign.builder()
+            .startDate(now.plusDays(2))
+            .endDate(now.plusDays(2))
+            .goalQuantity(10)
+            .soldQuantity(0)
+            .state(CampaignState.WAITING)
+            .member(member)
+            .now(now)
             .build();
     }
 

--- a/src/test/java/cholog/wiseshop/fixture/ProductFixture.java
+++ b/src/test/java/cholog/wiseshop/fixture/ProductFixture.java
@@ -1,7 +1,9 @@
 package cholog.wiseshop.fixture;
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest.CreateProductRequest;
+import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.product.Product;
+import cholog.wiseshop.db.stock.Stock;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class ProductFixture {
@@ -11,6 +13,21 @@ public class ProductFixture {
             .name("보약")
             .description("먹으면 기분이 좋아져요.")
             .price(10000)
+            .build();
+    }
+
+    public static Product 재고가_설정된_캠페인의_보약(Campaign campaign, Stock stock) {
+        return Product.builder()
+            .campaign(campaign)
+            .price(1000)
+            .stock(stock)
+            .build();
+    }
+
+    public static Product 캠페인의_보약(Campaign campaign) {
+        return Product.builder()
+            .campaign(campaign)
+            .price(1000)
             .build();
     }
 


### PR DESCRIPTION
## 작업내용
5차 상세 기능 명세에 따라 캠페인의 상세 기능 및 검증 로직을 추가했습니다.
아직 테스트가 작성되지 않아서요, pr draft로 해두고 테스트 추가 후 open 상태로 할게요!!
그리고 캠페인을 생성 할 때에, 기존에는 캠페인 상태를 바로 WAITING으로 했었는데,
```java
public CampaignState setState(LocalDateTime startDate, LocalDateTime endDate) {
        LocalDateTime now = LocalDateTime.now();
        if (endDate.isBefore(now)) {
            throw new WiseShopException(WiseShopErrorCode.CAMPAIGN_INVALID_DATE_RANGE);
        }
        if (startDate.isBefore(now) && now.isBefore(endDate)) {
            return CampaignState.IN_PROGRESS;
        }
        return CampaignState.WAITING;
    }
```
해당 메서드를 거친 후 설정하도록 변경했습니다. 이에 따라 캠페인 생성 시 스케줄링을 할 때에도 해당 메서드를 사용합니다.
이거 어떤가요?? 변경했으면 좋겠는 사항이나, 의문점이 있으면 말해주세요!!!