### PR TITLE
refactor: 로그인 시, UUID를 반환하도록 수정

### DIFF
--- a/src/main/java/cholog/wiseshop/api/member/controller/MemberController.java
+++ b/src/main/java/cholog/wiseshop/api/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package cholog.wiseshop.api.member.controller;
 
 import cholog.wiseshop.api.member.dto.request.SignInRequest;
 import cholog.wiseshop.api.member.dto.request.SignUpRequest;
+import cholog.wiseshop.api.member.dto.response.SignInResponse;
 import cholog.wiseshop.api.member.service.MemberService;
 import cholog.wiseshop.common.auth.Auth;
 import cholog.wiseshop.db.member.Member;
@@ -10,7 +11,6 @@ import jakarta.servlet.http.HttpSession;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,11 +33,12 @@ public class MemberController {
     }
 
     @PostMapping("/signin")
-    public ResponseEntity<Void> signIn(@RequestBody SignInRequest signInRequest,
+    public ResponseEntity<SignInResponse> signIn(@RequestBody SignInRequest signInRequest,
         HttpServletRequest httpServletRequest) {
         HttpSession session = httpServletRequest.getSession();
-        memberService.signInMember(signInRequest, session);
-        return ResponseEntity.ok().build();
+        SignInResponse response = memberService.signInMember(signInRequest, session);
+        return ResponseEntity.ok()
+            .body(response);
     }
 
     @DeleteMapping("/member")

--- a/src/main/java/cholog/wiseshop/api/member/dto/response/SignInResponse.java
+++ b/src/main/java/cholog/wiseshop/api/member/dto/response/SignInResponse.java
@@ -1,0 +1,5 @@
+package cholog.wiseshop.api.member.dto.response;
+
+public record SignInResponse(String uuid) {
+
+}

--- a/src/main/java/cholog/wiseshop/api/member/service/MemberService.java
+++ b/src/main/java/cholog/wiseshop/api/member/service/MemberService.java
@@ -2,6 +2,7 @@ package cholog.wiseshop.api.member.service;
 
 import cholog.wiseshop.api.member.dto.request.SignInRequest;
 import cholog.wiseshop.api.member.dto.request.SignUpRequest;
+import cholog.wiseshop.api.member.dto.response.SignInResponse;
 import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.campaign.CampaignState;
@@ -11,6 +12,7 @@ import cholog.wiseshop.exception.WiseShopErrorCode;
 import cholog.wiseshop.exception.WiseShopException;
 import jakarta.servlet.http.HttpSession;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,7 +45,7 @@ public class MemberService {
         memberRepository.save(member);
     }
 
-    public void signInMember(SignInRequest signInRequest, HttpSession session) {
+    public SignInResponse signInMember(SignInRequest signInRequest, HttpSession session) {
         Member member = memberRepository.findByEmail(signInRequest.email())
             .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.MEMBER_ID_NOT_FOUND));
         boolean matches = passwordEncoder.matches(signInRequest.password(), member.getPassword());
@@ -51,6 +53,7 @@ public class MemberService {
             throw new WiseShopException(WiseShopErrorCode.MEMBER_ID_NOT_FOUND);
         }
         session.setAttribute(SESSION_KEY, member);
+        return new SignInResponse(UUID.randomUUID().toString());
     }
 
     public void deleteMember(Member member) {


### PR DESCRIPTION
## 요약
![image](https://github.com/user-attachments/assets/8ad975eb-53a0-47ef-91ca-8921aeb6ccd4)
- 프론트 쪽에서 토스 PG 결제위젯을 생성할 때, `customerKey`가 필요합니다. 따라서 로그인 시, UUID를 생성해서 넘겨주도록 수정하였습니다.