### PR TITLE
feat: 사용자 기반 테스트 시나리오 구현

### DIFF
--- a/src/main/java/cholog/wiseshop/api/address/service/AddressService.java
+++ b/src/main/java/cholog/wiseshop/api/address/service/AddressService.java
@@ -8,7 +8,6 @@ import cholog.wiseshop.db.order.Order;
 import cholog.wiseshop.db.order.OrderRepository;
 import cholog.wiseshop.exception.WiseShopErrorCode;
 import cholog.wiseshop.exception.WiseShopException;
-import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,11 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class AddressService {
 
     private final AddressRepository addressRepository;
-    private final OrderRepository orderRepository;
 
-    public AddressService(AddressRepository addressRepository, OrderRepository orderRepository) {
+    public AddressService(AddressRepository addressRepository) {
         this.addressRepository = addressRepository;
-        this.orderRepository = orderRepository;
     }
 
     public Long createAddress(Member member, CreateAddressRequest request) {
@@ -30,24 +27,9 @@ public class AddressService {
     }
 
     public void deleteAddress(Member member, Long addressId) {
-//        Address address = addressRepository.findById(addressId)
-//            .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.ADDRESS_NOT_FOUND));
-//        validateAddressOwner(address, member);
-//        List<Order> orders = orderRepository
-//            .findByAddressIdAndMemberId(address.getId(), member.getId());
-//        /*
-//        * 아래의 배송 정보 삭제 정책 이상해요 주문한 상품이 배송 완료, 배송 중인지를 모르니
-//        * 그냥 주문 정보 있으면 삭제가 불가능하게 밖에 못했습니다.
-//         */
-//        if (!orders.isEmpty()) {
-//            throw new WiseShopException(WiseShopErrorCode.ADDRESS_EXIST_INTO_ORDER);
-//        }
-//        addressRepository.deleteById(addressId);
-    }
-
-    public void validateAddressOwner(Address address, Member member) {
-        if (!member.equals(address.getMember())) {
-            throw new WiseShopException(WiseShopErrorCode.ADDRESS_OWNER_MISMATCH);
-        }
+        Address address = addressRepository.findById(addressId)
+            .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.ADDRESS_NOT_FOUND));
+        address.validatesOwner(member);
+        addressRepository.deleteById(addressId);
     }
 }

--- a/src/main/java/cholog/wiseshop/db/address/Address.java
+++ b/src/main/java/cholog/wiseshop/db/address/Address.java
@@ -2,6 +2,8 @@ package cholog.wiseshop.db.address;
 
 import cholog.wiseshop.api.address.dto.CreateAddressRequest;
 import cholog.wiseshop.db.member.Member;
+import cholog.wiseshop.exception.WiseShopErrorCode;
+import cholog.wiseshop.exception.WiseShopException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -84,5 +86,11 @@ public class Address {
             request.isDefault(),
             member
         );
+    }
+
+    public void validatesOwner(Member member) {
+        if (!getMember().getEmail().equals(member.getEmail())) {
+            throw new WiseShopException(WiseShopErrorCode.ADDRESS_OWNER_MISMATCH);
+        }
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/AddressServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/AddressServiceTest.java
@@ -10,6 +10,7 @@ import cholog.wiseshop.db.address.Address;
 import cholog.wiseshop.db.address.AddressRepository;
 import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.member.MemberRepository;
+import cholog.wiseshop.exception.WiseShopErrorCode;
 import cholog.wiseshop.exception.WiseShopException;
 import cholog.wiseshop.fixture.AddressFixture;
 import cholog.wiseshop.fixture.MemberFixture;
@@ -82,6 +83,7 @@ public class AddressServiceTest extends BaseTest {
 
         // when & then
         assertThatThrownBy(() -> addressService.deleteAddress(junesoo, address.getId()))
-            .isInstanceOf(WiseShopException.class);
+            .isInstanceOf(WiseShopException.class)
+            .hasMessage(WiseShopErrorCode.ADDRESS_OWNER_MISMATCH.getMessage());
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/AddressServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/AddressServiceTest.java
@@ -1,0 +1,76 @@
+package cholog.wiseshop.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import cholog.wiseshop.api.address.dto.CreateAddressRequest;
+import cholog.wiseshop.api.address.service.AddressService;
+import cholog.wiseshop.common.BaseTest;
+import cholog.wiseshop.db.address.Address;
+import cholog.wiseshop.db.address.AddressRepository;
+import cholog.wiseshop.db.member.Member;
+import cholog.wiseshop.db.member.MemberRepository;
+import cholog.wiseshop.fixture.AddressFixture;
+import cholog.wiseshop.fixture.MemberFixture;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class AddressServiceTest extends BaseTest {
+
+    @Autowired
+    private AddressRepository addressRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private AddressService addressService;
+
+    @Nested
+    class 사용자가_배송지를_등록한다 {
+
+        @Test
+        void 사용자가_배송지를_정상적으로_등록한다() {
+            // given
+            Member member = MemberFixture.최준호();
+            memberRepository.save(member);
+            CreateAddressRequest request = new CreateAddressRequest(
+                06160,
+                "서울특별시 강남구 삼성동 142-35",
+                "13층",
+                true
+            );
+
+            // when
+            Long addressId = addressService.createAddress(member, request);
+
+            // then
+            assertThat(addressRepository.findById(addressId)).isNotEmpty();
+        }
+    }
+
+    @Nested
+    class 사용자가_배송지를_삭제한다 {
+
+        @Test
+        void 사용자가_배송지를_정상적으로_삭제한다() {
+            // given
+            Member member = MemberFixture.최준호();
+            memberRepository.save(member);
+            Address address = AddressFixture.집주소(member);
+            addressRepository.save(address);
+
+            // when
+            addressService.deleteAddress(member, address.getId());
+
+            // then
+            assertThat(addressRepository.findById(address.getId())).isEmpty();
+        }
+    }
+
+    @Test
+    void 배송지_소유가_삭제를_요청한_사용자와_다르면_예외_발생() {
+
+    }
+}

--- a/src/test/java/cholog/wiseshop/domain/AddressServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/AddressServiceTest.java
@@ -1,6 +1,7 @@
 package cholog.wiseshop.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import cholog.wiseshop.api.address.dto.CreateAddressRequest;
 import cholog.wiseshop.api.address.service.AddressService;
@@ -9,6 +10,7 @@ import cholog.wiseshop.db.address.Address;
 import cholog.wiseshop.db.address.AddressRepository;
 import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.member.MemberRepository;
+import cholog.wiseshop.exception.WiseShopException;
 import cholog.wiseshop.fixture.AddressFixture;
 import cholog.wiseshop.fixture.MemberFixture;
 import org.junit.jupiter.api.Nested;
@@ -71,6 +73,15 @@ public class AddressServiceTest extends BaseTest {
 
     @Test
     void 배송지_소유가_삭제를_요청한_사용자와_다르면_예외_발생() {
+        // given
+        Member junho = MemberFixture.최준호();
+        Member junesoo = MemberFixture.김준수();
+        memberRepository.save(junho);
+        Address address = AddressFixture.집주소(junho);
+        addressRepository.save(address);
 
+        // when & then
+        assertThatThrownBy(() -> addressService.deleteAddress(junesoo, address.getId()))
+            .isInstanceOf(WiseShopException.class);
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/CampaignServiceTest.java
@@ -1,4 +1,4 @@
-package cholog.wiseshop.domain.member;
+package cholog.wiseshop.domain;
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest;
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest.CreateProductRequest;

--- a/src/test/java/cholog/wiseshop/domain/MemberServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/MemberServiceTest.java
@@ -1,7 +1,6 @@
-package cholog.wiseshop.domain.member;
+package cholog.wiseshop.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import cholog.wiseshop.api.member.dto.request.SignUpRequest;
@@ -88,7 +87,8 @@ class MemberServiceTest extends BaseTest {
             // given
             Member member = MemberFixture.최준호();
             memberRepository.save(member);
-            campaignRepository.save(CampaignFixture.진행중인_보약_캠페인(member));
+            Campaign campaign = CampaignFixture.진행중인_보약_캠페인(member);
+            campaignRepository.save(campaign);
 
             // when & then
             assertThatThrownBy(() -> memberService.deleteMember(member))

--- a/src/test/java/cholog/wiseshop/domain/MemberServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/MemberServiceTest.java
@@ -10,6 +10,7 @@ import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.member.MemberRepository;
+import cholog.wiseshop.exception.WiseShopErrorCode;
 import cholog.wiseshop.exception.WiseShopException;
 import cholog.wiseshop.fixture.CampaignFixture;
 import cholog.wiseshop.fixture.MemberFixture;
@@ -62,7 +63,8 @@ class MemberServiceTest extends BaseTest {
 
             // when & then
             assertThatThrownBy(() -> memberService.signUpMember(request))
-                .isInstanceOf(WiseShopException.class);
+                .isInstanceOf(WiseShopException.class)
+                .hasMessage(WiseShopErrorCode.ALREADY_EXIST_MEMBER.getMessage());
         }
     }
 
@@ -92,7 +94,8 @@ class MemberServiceTest extends BaseTest {
 
             // when & then
             assertThatThrownBy(() -> memberService.deleteMember(member))
-                .isInstanceOf(WiseShopException.class);
+                .isInstanceOf(WiseShopException.class)
+                .hasMessage(WiseShopErrorCode.MEMBER_INPROGRESS_CAMPAIGN_EXIST.getMessage());
         }
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/ProductServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/ProductServiceTest.java
@@ -1,4 +1,4 @@
-package cholog.wiseshop.domain.member;
+package cholog.wiseshop.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/cholog/wiseshop/domain/member/MemberServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/member/MemberServiceTest.java
@@ -8,6 +8,7 @@ import cholog.wiseshop.api.member.dto.request.SignUpRequest;
 import cholog.wiseshop.api.member.service.MemberService;
 import cholog.wiseshop.common.BaseTest;
 import cholog.wiseshop.db.campaign.Campaign;
+import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.member.MemberRepository;
 import cholog.wiseshop.exception.WiseShopException;
@@ -22,6 +23,9 @@ class MemberServiceTest extends BaseTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private CampaignRepository campaignRepository;
 
     @Autowired
     private MemberService memberService;
@@ -84,13 +88,11 @@ class MemberServiceTest extends BaseTest {
             // given
             Member member = MemberFixture.최준호();
             memberRepository.save(member);
-            Campaign campaign = CampaignFixture.보약_캠페인(member);
+            campaignRepository.save(CampaignFixture.진행중인_보약_캠페인(member));
 
-            // when
-
-
-            // then
-
+            // when & then
+            assertThatThrownBy(() -> memberService.deleteMember(member))
+                .isInstanceOf(WiseShopException.class);
         }
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/member/MemberServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/member/MemberServiceTest.java
@@ -1,14 +1,17 @@
 package cholog.wiseshop.domain.member;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import cholog.wiseshop.api.member.dto.request.SignUpRequest;
 import cholog.wiseshop.api.member.service.MemberService;
 import cholog.wiseshop.common.BaseTest;
+import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.member.MemberRepository;
 import cholog.wiseshop.exception.WiseShopException;
+import cholog.wiseshop.fixture.CampaignFixture;
 import cholog.wiseshop.fixture.MemberFixture;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -57,6 +60,37 @@ class MemberServiceTest extends BaseTest {
             // when & then
             assertThatThrownBy(() -> memberService.signUpMember(request))
                 .isInstanceOf(WiseShopException.class);
+        }
+    }
+
+    @Nested
+    class 사용자가_회원탈퇴를_수행한다 {
+
+        @Test
+        void 사용자가_회원탈퇴를_정상적으로_수행한다() {
+            // given
+            Member member = MemberFixture.최준호();
+            memberRepository.save(member);
+
+            // when
+            memberService.deleteMember(member);
+
+            // then
+            assertThat(memberRepository.findById(member.getId())).isEmpty();
+        }
+
+        @Test
+        void 진행중인_캠페인이_존재하면_예외() {
+            // given
+            Member member = MemberFixture.최준호();
+            memberRepository.save(member);
+            Campaign campaign = CampaignFixture.보약_캠페인(member);
+
+            // when
+
+
+            // then
+
         }
     }
 }

--- a/src/test/java/cholog/wiseshop/fixture/AddressFixture.java
+++ b/src/test/java/cholog/wiseshop/fixture/AddressFixture.java
@@ -1,0 +1,20 @@
+package cholog.wiseshop.fixture;
+
+import cholog.wiseshop.db.address.Address;
+import cholog.wiseshop.db.member.Member;
+import org.springframework.stereotype.Component;
+
+@Component
+@SuppressWarnings("NonAsciiCharacters")
+public class AddressFixture {
+
+    public static Address 집주소(Member member) {
+        return new Address(
+            06160,
+            "서울특별시 강남구 삼성동 142-35",
+            "13층",
+            true,
+            member
+        );
+    }
+}

--- a/src/test/java/cholog/wiseshop/fixture/CampaignFixture.java
+++ b/src/test/java/cholog/wiseshop/fixture/CampaignFixture.java
@@ -18,4 +18,15 @@ public class CampaignFixture {
             .member(member)
             .build();
     }
+
+    public static Campaign 진행중인_보약_캠페인(Member member) {
+        LocalDateTime now = LocalDateTime.now();
+        return Campaign.builder()
+            .startDate(now.minusDays(3))
+            .endDate(now.plusDays(5))
+            .goalQuantity(100)
+            .soldQuantity(0)
+            .member(member)
+            .build();
+    }
 }

--- a/src/test/java/cholog/wiseshop/fixture/CampaignFixture.java
+++ b/src/test/java/cholog/wiseshop/fixture/CampaignFixture.java
@@ -1,6 +1,7 @@
 package cholog.wiseshop.fixture;
 
 import cholog.wiseshop.db.campaign.Campaign;
+import cholog.wiseshop.db.campaign.CampaignState;
 import cholog.wiseshop.db.member.Member;
 import java.time.LocalDateTime;
 
@@ -22,11 +23,13 @@ public class CampaignFixture {
     public static Campaign 진행중인_보약_캠페인(Member member) {
         LocalDateTime now = LocalDateTime.now();
         return Campaign.builder()
-            .startDate(now.minusDays(3))
-            .endDate(now.plusDays(5))
+            .startDate(now.plusDays(1))
+            .endDate(now.plusDays(2))
             .goalQuantity(100)
             .soldQuantity(0)
+            .state(CampaignState.IN_PROGRESS)
             .member(member)
+            .now(now)
             .build();
     }
 }

--- a/src/test/java/cholog/wiseshop/fixture/MemberFixture.java
+++ b/src/test/java/cholog/wiseshop/fixture/MemberFixture.java
@@ -14,4 +14,12 @@ public class MemberFixture {
             "12341234"
         );
     }
+
+    public static Member 김준수() {
+        return new Member(
+            "junesoo@test.com",
+            "김준수",
+            "12341234"
+        );
+    }
 }


### PR DESCRIPTION
### 요약
- 시나리오에 따른 회원, 배송 테스트를 구현했습니다.
- 회원
   - 회원 삭제
   - (정책) 회원 삭제 시 진행중인 캠페인이 존재하면 발생하는 예외
- 배송지
   - 배송지 등록
   - 배송지 삭제
   - (정책)배송지 삭제 시 소유자가 아닌 다른 회원이 요청할 경우 발생하는 예외