### PR TITLE
feat: 상품 상세 기능 추가 구현

### DIFF
--- a/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
+++ b/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
@@ -37,11 +37,11 @@ public class ProductController {
     }
 
     @PatchMapping("/products/{id}/price")
-    public ResponseEntity<Void> modifyProductPrice(
+    public ResponseEntity<Void> modifyProductPriceAndStock(
         @PathVariable Long id,
         @RequestBody ModifyProductPriceRequest request
     ) {
-        productService.modifyProductPrice(id, request);
+        productService.modifyProductPriceAndStock(id, request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
+++ b/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
@@ -1,6 +1,6 @@
 package cholog.wiseshop.api.product.controller;
 
-import cholog.wiseshop.api.product.dto.request.ModifyProductPriceRequest;
+import cholog.wiseshop.api.product.dto.request.ModifyProductPriceAntStockRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.api.product.service.ProductService;
@@ -40,7 +40,7 @@ public class ProductController {
     @PatchMapping("/products/{id}/price")
     public ResponseEntity<Void> modifyProductPriceAndStock(
         @PathVariable Long id,
-        @RequestBody ModifyProductPriceRequest request
+        @RequestBody ModifyProductPriceAntStockRequest request
     ) {
         productService.modifyProductPriceAndStock(id, request);
         return ResponseEntity.ok().build();

--- a/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
+++ b/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
@@ -26,7 +26,8 @@ public class ProductController {
 
     @GetMapping("/products/{id}")
     public ResponseEntity<ProductResponse> getProduct(@PathVariable Long id) {
-        return ResponseEntity.status(HttpStatus.OK).body(productService.getProduct(id));
+        ProductResponse response = productService.getProduct(id);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
     @PatchMapping("/products/{id}")

--- a/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
+++ b/src/main/java/cholog/wiseshop/api/product/controller/ProductController.java
@@ -1,6 +1,6 @@
 package cholog.wiseshop.api.product.controller;
 
-import cholog.wiseshop.api.product.dto.request.ModifyProductPriceAntStockRequest;
+import cholog.wiseshop.api.product.dto.request.ModifyProductPriceAndStockRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.api.product.service.ProductService;
@@ -40,7 +40,7 @@ public class ProductController {
     @PatchMapping("/products/{id}/price")
     public ResponseEntity<Void> modifyProductPriceAndStock(
         @PathVariable Long id,
-        @RequestBody ModifyProductPriceAntStockRequest request
+        @RequestBody ModifyProductPriceAndStockRequest request
     ) {
         productService.modifyProductPriceAndStock(id, request);
         return ResponseEntity.ok().build();

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductPriceAndStockRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductPriceAndStockRequest.java
@@ -1,6 +1,6 @@
 package cholog.wiseshop.api.product.dto.request;
 
-public record ModifyProductPriceAntStockRequest(
+public record ModifyProductPriceAndStockRequest(
     int price,
     int totalQuantity
 ) {

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductPriceAntStockRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductPriceAntStockRequest.java
@@ -1,6 +1,6 @@
 package cholog.wiseshop.api.product.dto.request;
 
-public record ModifyProductPriceRequest(
+public record ModifyProductPriceAntStockRequest(
     int price,
     int totalQuantity
 ) {

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductPriceRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductPriceRequest.java
@@ -1,5 +1,8 @@
 package cholog.wiseshop.api.product.dto.request;
 
-public record ModifyProductPriceRequest(int price) {
+public record ModifyProductPriceRequest(
+    int price,
+    int totalQuantity
+) {
 
 }

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyProductRequest.java
@@ -1,5 +1,8 @@
 package cholog.wiseshop.api.product.dto.request;
 
-public record ModifyProductRequest(String name, String description) {
+public record ModifyProductRequest(
+    String name,
+    String description
+) {
 
 }

--- a/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyQuantityRequest.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/request/ModifyQuantityRequest.java
@@ -1,7 +1,9 @@
 package cholog.wiseshop.api.product.dto.request;
 
-public record ModifyQuantityRequest(Long campaignId,
-                                    Long productId,
-                                    Integer modifyQuantity) {
+public record ModifyQuantityRequest(
+    Long campaignId,
+    Long productId,
+    Integer modifyQuantity
+) {
 
 }

--- a/src/main/java/cholog/wiseshop/api/product/dto/response/ProductResponse.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/response/ProductResponse.java
@@ -2,11 +2,13 @@ package cholog.wiseshop.api.product.dto.response;
 
 import cholog.wiseshop.db.product.Product;
 
-public record ProductResponse(Long id,
-                              String name,
-                              String description,
-                              Integer price,
-                              Integer totalQuantity) {
+public record ProductResponse(
+    Long id,
+    String name,
+    String description,
+    Integer price,
+    Integer totalQuantity
+) {
 
     public ProductResponse(Product product) {
         this(

--- a/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
+++ b/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
@@ -26,19 +26,6 @@ public class ProductService {
         this.campaignRepository = campaignRepository;
     }
 
-    // TODO: 안쓰면 제거
-    public Long createProduct(CreateProductRequest request) {
-        Stock stock = new Stock(request.totalQuantity());
-        Product product = Product.builder()
-            .name(request.name())
-            .description(request.description())
-            .price(request.price())
-            .stock(stock)
-            .build();
-        Product createdProduct = productRepository.save(product);
-        return createdProduct.getId();
-    }
-
     @Transactional(readOnly = true)
     public ProductResponse getProduct(Long id) {
         return new ProductResponse(productRepository.findById(id)

--- a/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
+++ b/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
@@ -49,11 +49,11 @@ public class ProductService {
         productRepository.save(existedProduct);
     }
 
-    public void modifyProductPrice(Long productId, ModifyProductPriceRequest request) {
+    public void modifyProductPriceAndStock(Long productId, ModifyProductPriceRequest request) {
         Product existedProduct = productRepository.findById(productId)
             .orElseThrow(
                 () -> new WiseShopException(WiseShopErrorCode.MODIFY_PRICE_PRODUCT_NOT_FOUND));
-        existedProduct.modifyPrice(request.price());
+        existedProduct.modifyPriceAndStock(request.price(), request.totalQuantity());
         productRepository.save(existedProduct);
     }
 

--- a/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
+++ b/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
@@ -58,8 +58,11 @@ public class ProductService {
     }
 
     public void deleteProduct(Long id) {
-        productRepository.findById(id)
+        Product product = productRepository.findById(id)
             .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.PRODUCT_NOT_FOUND));
+        if (product.getCampaign().isNotWaiting()) {
+            throw new WiseShopException(WiseShopErrorCode.INVALID_CAMPAIGN_DELETE_STATE);
+        }
         productRepository.deleteById(id);
     }
 }

--- a/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
+++ b/src/main/java/cholog/wiseshop/api/product/service/ProductService.java
@@ -1,7 +1,7 @@
 package cholog.wiseshop.api.product.service;
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest.CreateProductRequest;
-import cholog.wiseshop.api.product.dto.request.ModifyProductPriceAntStockRequest;
+import cholog.wiseshop.api.product.dto.request.ModifyProductPriceAndStockRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.db.campaign.Campaign;
@@ -53,10 +53,9 @@ public class ProductService {
         productRepository.save(existedProduct);
     }
 
-    public void modifyProductPriceAndStock(Long productId, ModifyProductPriceAntStockRequest request) {
+    public void modifyProductPriceAndStock(Long productId, ModifyProductPriceAndStockRequest request) {
         Product existedProduct = productRepository.findById(productId)
-            .orElseThrow(
-                () -> new WiseShopException(WiseShopErrorCode.MODIFY_PRICE_PRODUCT_NOT_FOUND));
+            .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.MODIFY_PRICE_PRODUCT_NOT_FOUND));
         existedProduct.modifyPriceAndStock(request.price(), request.totalQuantity());
         productRepository.save(existedProduct);
     }

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -194,4 +194,8 @@ public class Campaign {
     public boolean isInProgress() {
         return CampaignState.IN_PROGRESS.equals(state);
     }
+
+    public boolean isNotWaiting() {
+        return !CampaignState.WAITING.equals(state);
+    }
 }

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -195,7 +195,11 @@ public class Campaign {
         return CampaignState.IN_PROGRESS.equals(state);
     }
 
+    public boolean isWaiting() {
+        return CampaignState.WAITING.equals(state);
+    }
+
     public boolean isNotWaiting() {
-        return !CampaignState.WAITING.equals(state);
+        return !isWaiting();
     }
 }

--- a/src/main/java/cholog/wiseshop/db/product/Product.java
+++ b/src/main/java/cholog/wiseshop/db/product/Product.java
@@ -2,6 +2,8 @@ package cholog.wiseshop.db.product;
 
 import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.stock.Stock;
+import cholog.wiseshop.exception.WiseShopErrorCode;
+import cholog.wiseshop.exception.WiseShopException;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -99,8 +101,15 @@ public class Product {
         this.campaign = campaign;
     }
 
-    public void modifyPrice(int price) {
+    public void modifyPriceAndStock(int price, int totalQuantity) {
+        if (campaign.isInProgress()) {
+            throw new WiseShopException(WiseShopErrorCode.CAMPAIGN_ALREADY_IN_PROGRESS);
+        }
+        if (totalQuantity <= campaign.getGoalQuantity()) {
+            throw new WiseShopException(WiseShopErrorCode.INVALID_TOTAL_QUANTITY);
+        }
         this.price = price;
+        this.stock.modifyTotalQuantity(totalQuantity);
     }
 
     public Long getId() {

--- a/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
+++ b/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
@@ -22,7 +22,8 @@ public enum WiseShopErrorCode {
     ORDER_NOT_AVAILABLE("자신이 만든 캠페인은 주문이 불가능합니다."),
     CAMPAIGN_INVALID_DATE_RANGE("잘못된 캠페인 날짜입니다."),
     INVALID_GOAL_QUANTITY("목표수량은 재고보다 적어야 합니다."),
-    INVALID_TOTAL_QUANTITY("재고는 목표수량보다 많아야 합니다.");
+    INVALID_TOTAL_QUANTITY("재고는 목표수량보다 많아야 합니다."),
+    INVALID_CAMPAIGN_DELETE_STATE("판매 대기 중이 아닌 상품은 삭제할 수 없습니다.");
 
     private String message;
 

--- a/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
+++ b/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
@@ -21,7 +21,8 @@ public enum WiseShopErrorCode {
     ORDER_NOT_FOUND("주문 정보가 존재하지 않습니다."),
     ORDER_NOT_AVAILABLE("자신이 만든 캠페인은 주문이 불가능합니다."),
     CAMPAIGN_INVALID_DATE_RANGE("잘못된 캠페인 날짜입니다."),
-    INVALID_GOAL_QUANTITY("목표수량은 재고보다 적어야 합니다.");
+    INVALID_GOAL_QUANTITY("목표수량은 재고보다 적어야 합니다."),
+    INVALID_TOTAL_QUANTITY("재고는 목표수량보다 많아야 합니다.");
 
     private String message;
 

--- a/src/test/java/cholog/wiseshop/domain/ProductServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/ProductServiceTest.java
@@ -3,7 +3,7 @@ package cholog.wiseshop.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import cholog.wiseshop.api.product.dto.request.ModifyProductPriceAntStockRequest;
+import cholog.wiseshop.api.product.dto.request.ModifyProductPriceAndStockRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
 import cholog.wiseshop.api.product.service.ProductService;
 import cholog.wiseshop.common.BaseTest;
@@ -76,7 +76,7 @@ class ProductServiceTest extends BaseTest {
             Stock stock = new Stock(20);
             stockRepository.save(stock);
             Product product = productRepository.save(ProductFixture.재고가_설정된_캠페인의_보약(campaign, stock));
-            ModifyProductPriceAntStockRequest request = new ModifyProductPriceAntStockRequest(
+            ModifyProductPriceAndStockRequest request = new ModifyProductPriceAndStockRequest(
                 2000,
                 30
             );
@@ -98,7 +98,7 @@ class ProductServiceTest extends BaseTest {
             Stock stock = new Stock(20);
             stockRepository.save(stock);
             Product product = productRepository.save(ProductFixture.재고가_설정된_캠페인의_보약(campaign, stock));
-            ModifyProductPriceAntStockRequest request = new ModifyProductPriceAntStockRequest(
+            ModifyProductPriceAndStockRequest request = new ModifyProductPriceAndStockRequest(
                 2000,
                 30
             );
@@ -117,7 +117,7 @@ class ProductServiceTest extends BaseTest {
             Stock stock = new Stock(20);
             stockRepository.save(stock);
             Product product = productRepository.save(ProductFixture.재고가_설정된_캠페인의_보약(campaign, stock));
-            ModifyProductPriceAntStockRequest request = new ModifyProductPriceAntStockRequest(
+            ModifyProductPriceAndStockRequest request = new ModifyProductPriceAndStockRequest(
                 2000,
                 1
             );
@@ -126,7 +126,6 @@ class ProductServiceTest extends BaseTest {
             assertThatThrownBy(() -> productService.modifyProductPriceAndStock(product.getId(), request))
                 .isInstanceOf(WiseShopException.class)
                 .hasMessage(WiseShopErrorCode.INVALID_TOTAL_QUANTITY.getMessage());
-
         }
     }
 

--- a/src/test/java/cholog/wiseshop/domain/ProductServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/ProductServiceTest.java
@@ -1,12 +1,24 @@
 package cholog.wiseshop.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import cholog.wiseshop.api.product.dto.request.ModifyProductPriceAntStockRequest;
 import cholog.wiseshop.api.product.dto.request.ModifyProductRequest;
 import cholog.wiseshop.api.product.service.ProductService;
 import cholog.wiseshop.common.BaseTest;
+import cholog.wiseshop.db.campaign.Campaign;
+import cholog.wiseshop.db.campaign.CampaignRepository;
+import cholog.wiseshop.db.member.Member;
+import cholog.wiseshop.db.member.MemberRepository;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
+import cholog.wiseshop.db.stock.Stock;
+import cholog.wiseshop.db.stock.StockRepository;
+import cholog.wiseshop.exception.WiseShopErrorCode;
+import cholog.wiseshop.exception.WiseShopException;
+import cholog.wiseshop.fixture.CampaignFixture;
+import cholog.wiseshop.fixture.MemberFixture;
 import cholog.wiseshop.fixture.ProductFixture;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Nested;
@@ -21,6 +33,15 @@ class ProductServiceTest extends BaseTest {
 
     @Autowired
     private ProductRepository productRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CampaignRepository campaignRepository;
+
+    @Autowired
+    private StockRepository stockRepository;
 
     @Nested
     class 상품_정보를_수정한다 {
@@ -45,6 +66,99 @@ class ProductServiceTest extends BaseTest {
                     assertThat(modified.getDescription()).isEqualTo("수정된 보약 설명");
                 }
             );
+        }
+
+        @Test
+        void 상품의_가격과_재고를_정상적으로_수정한다() {
+            // given
+            Member member = memberRepository.save(MemberFixture.최준호());
+            Campaign campaign = campaignRepository.save(CampaignFixture.대기중인_보약_캠페인(member));
+            Stock stock = new Stock(20);
+            stockRepository.save(stock);
+            Product product = productRepository.save(ProductFixture.재고가_설정된_캠페인의_보약(campaign, stock));
+            ModifyProductPriceAntStockRequest request = new ModifyProductPriceAntStockRequest(
+                2000,
+                30
+            );
+
+            // when
+            productService.modifyProductPriceAndStock(product.getId(), request);
+
+            // then
+            Product modified = productRepository.findById(product.getId()).get();
+            assertThat(modified.getPrice()).isEqualTo(2000);
+            assertThat(modified.getStock().getTotalQuantity()).isEqualTo(30);
+        }
+
+        @Test
+        void 캠페인이_진행중일_경우_상품가격과_재고를_수정할_수_없다() {
+            // given
+            Member member = memberRepository.save(MemberFixture.최준호());
+            Campaign campaign = campaignRepository.save(CampaignFixture.진행중인_보약_캠페인(member));
+            Stock stock = new Stock(20);
+            stockRepository.save(stock);
+            Product product = productRepository.save(ProductFixture.재고가_설정된_캠페인의_보약(campaign, stock));
+            ModifyProductPriceAntStockRequest request = new ModifyProductPriceAntStockRequest(
+                2000,
+                30
+            );
+
+            // when & then
+            assertThatThrownBy(() -> productService.modifyProductPriceAndStock(product.getId(), request))
+                .isInstanceOf(WiseShopException.class)
+                .hasMessage(WiseShopErrorCode.CAMPAIGN_ALREADY_IN_PROGRESS.getMessage());
+        }
+
+        @Test
+        void 재고를_목표수량보다_적게_수정할_수_없다() {
+            // given
+            Member member = memberRepository.save(MemberFixture.최준호());
+            Campaign campaign = campaignRepository.save(CampaignFixture.대기중인_보약_캠페인(member));
+            Stock stock = new Stock(20);
+            stockRepository.save(stock);
+            Product product = productRepository.save(ProductFixture.재고가_설정된_캠페인의_보약(campaign, stock));
+            ModifyProductPriceAntStockRequest request = new ModifyProductPriceAntStockRequest(
+                2000,
+                1
+            );
+
+            // when & then
+            assertThatThrownBy(() -> productService.modifyProductPriceAndStock(product.getId(), request))
+                .isInstanceOf(WiseShopException.class)
+                .hasMessage(WiseShopErrorCode.INVALID_TOTAL_QUANTITY.getMessage());
+
+        }
+    }
+
+    @Nested
+    class 상품을_삭제한다 {
+
+        @Test
+        void 상품_하나를_정상적으로_삭제한다() {
+            // given
+            Member member = memberRepository.save(MemberFixture.최준호());
+            Campaign campaign = campaignRepository.save(CampaignFixture.대기중인_보약_캠페인(member));
+            Product product = productRepository.save(ProductFixture.캠페인의_보약(campaign));
+
+            // when
+            productService.deleteProduct(product.getId());
+
+            //then
+            assertThat(productRepository.findById(product.getId())).isEmpty();
+            assertThat(campaignRepository.findById(campaign.getId())).isEmpty();
+        }
+
+        @Test
+        void 캠페인이_진행중이면_상품을_삭제할_수_없다() {
+            // given
+            Member member = memberRepository.save(MemberFixture.최준호());
+            Campaign campaign = campaignRepository.save(CampaignFixture.진행중인_보약_캠페인(member));
+            Product product = productRepository.save(ProductFixture.캠페인의_보약(campaign));
+
+            // when & then
+            assertThatThrownBy(() -> productService.deleteProduct(product.getId()))
+                .isInstanceOf(WiseShopException.class)
+                .hasMessage(WiseShopErrorCode.INVALID_CAMPAIGN_DELETE_STATE.getMessage());
         }
     }
 }

--- a/src/test/java/cholog/wiseshop/fixture/CampaignFixture.java
+++ b/src/test/java/cholog/wiseshop/fixture/CampaignFixture.java
@@ -17,6 +17,20 @@ public class CampaignFixture {
             .goalQuantity(100)
             .soldQuantity(0)
             .member(member)
+            .now(now)
+            .build();
+    }
+
+    public static Campaign 대기중인_보약_캠페인(Member member) {
+        LocalDateTime now = LocalDateTime.now();
+        return Campaign.builder()
+            .startDate(now.plusDays(2))
+            .endDate(now.plusDays(2))
+            .goalQuantity(10)
+            .soldQuantity(0)
+            .state(CampaignState.WAITING)
+            .member(member)
+            .now(now)
             .build();
     }
 

--- a/src/test/java/cholog/wiseshop/fixture/ProductFixture.java
+++ b/src/test/java/cholog/wiseshop/fixture/ProductFixture.java
@@ -1,7 +1,9 @@
 package cholog.wiseshop.fixture;
 
 import cholog.wiseshop.api.campaign.dto.request.CreateCampaignRequest.CreateProductRequest;
+import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.product.Product;
+import cholog.wiseshop.db.stock.Stock;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class ProductFixture {
@@ -11,6 +13,21 @@ public class ProductFixture {
             .name("보약")
             .description("먹으면 기분이 좋아져요.")
             .price(10000)
+            .build();
+    }
+
+    public static Product 재고가_설정된_캠페인의_보약(Campaign campaign, Stock stock) {
+        return Product.builder()
+            .campaign(campaign)
+            .price(1000)
+            .stock(stock)
+            .build();
+    }
+
+    public static Product 캠페인의_보약(Campaign campaign) {
+        return Product.builder()
+            .campaign(campaign)
+            .price(1000)
             .build();
     }
 


### PR DESCRIPTION
## 작업내용
상품의 상세 기능을 추가구현했습니다.
노션의 5차 상세 기능 페이지를 기반으로 구현했습니다.
상품 상태 관리에 대해서는(enum으로 AVAILABLE과 SOLD_OUT) 변경지점이 너무 켜져서요...이 지점에 대해 데일리미팅에서 준수와 논의하긴했어요, 결론은 우선순위에서 미루었습니다...!
주문이 들어왔을때 검증하는 방향으로 가도 좋을 것 같아요

지금 pr "먼저" 머지 후 
https://github.com/cholog-project/wiseshop/pull/64 <-이 pr을 다음에 머지해야해요