### PR TITLE
feat: Swagger에서 Post 요청 시 회원 검증 정보 숨기기

### DIFF
--- a/src/main/java/cholog/wiseshop/common/auth/Auth.java
+++ b/src/main/java/cholog/wiseshop/common/auth/Auth.java
@@ -1,5 +1,6 @@
 package cholog.wiseshop.common.auth;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,6 +8,7 @@ import java.lang.annotation.Target;
 
 @Target({ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
+@Hidden
 public @interface Auth {
 
 }


### PR DESCRIPTION
### 요약
- @Choi-JJunho 님이 알려주신 Swagger에서 Post 요청 시 회원 정보를 받는 부분을 `@Hidden` 어노테이션을 활용해서 숨겼습니당