### PR TITLE
refactor: 진행중인 캠페인 조회에서 전체 캠페인 조회로 변경

### DIFF
--- a/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
@@ -42,7 +42,7 @@ public class CampaignController {
 
     @GetMapping
     public ResponseEntity<List<ReadCampaignResponse>> readAllCampaign() {
-        var response = campaignService.readInProgressCampaign();
+        var response = campaignService.readAllCampaign();
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/dto/response/ReadCampaignResponse.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/dto/response/ReadCampaignResponse.java
@@ -1,6 +1,7 @@
 package cholog.wiseshop.api.campaign.dto.response;
 
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
+import cholog.wiseshop.db.campaign.CampaignState;
 
 public record ReadCampaignResponse(
     Long campaignId,
@@ -9,6 +10,7 @@ public record ReadCampaignResponse(
     int goalQuantity,
     int orderedQuantity,
     int stockQuantity,
+    CampaignState state,
     ProductResponse product,
     Long ownerId
 ) {

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -90,13 +90,14 @@ public class CampaignService {
             findCampaign.getEndDate().toString(), findCampaign.getGoalQuantity(),
             findCampaign.getSoldQuantity(),
             findProduct.getStock().getTotalQuantity(),
+            findCampaign.getState(),
             new ProductResponse(findProduct),
             findCampaign.getMember().getId()
         );
     }
 
-    public List<ReadCampaignResponse> readInProgressCampaign() {
-        List<Campaign> campaigns = campaignRepository.findAllByState(CampaignState.IN_PROGRESS);
+    public List<ReadCampaignResponse> readAllCampaign() {
+        List<Campaign> campaigns = campaignRepository.findAll();
         return campaigns.stream()
             .map(campaign -> {
                 Product product = productRepository.findAllByCampaign(campaign).getFirst();
@@ -107,6 +108,7 @@ public class CampaignService {
                     campaign.getGoalQuantity(),
                     campaign.getSoldQuantity(),
                     product.getStock().getTotalQuantity(),
+                    campaign.getState(),
                     new ProductResponse(product),
                     campaign.getMember().getId()
                 );

--- a/src/test/java/cholog/wiseshop/domain/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/CampaignServiceTest.java
@@ -183,7 +183,7 @@ public class CampaignServiceTest extends BaseTest {
         }
 
         @Test
-        void 캠페인_전체조회_시_진행중_캠페인들만_조회() {
+        void 캠페인_전체조회_성공적으로_조회() {
             // given
             Member member = memberRepository.save(MemberFixture.최준호());
             LocalDateTime now = LocalDateTime.now();
@@ -231,7 +231,7 @@ public class CampaignServiceTest extends BaseTest {
             List<ReadCampaignResponse> response = campaignService.readAllCampaign();
 
             // then
-            assertThat(response).hasSize(2);
+            assertThat(response).hasSize(3);
         }
 
         @Test

--- a/src/test/java/cholog/wiseshop/domain/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/CampaignServiceTest.java
@@ -228,7 +228,7 @@ public class CampaignServiceTest extends BaseTest {
             productRepository.saveAll(List.of(productA, productB, productC));
 
             // when
-            List<ReadCampaignResponse> response = campaignService.readInProgressCampaign();
+            List<ReadCampaignResponse> response = campaignService.readAllCampaign();
 
             // then
             assertThat(response).hasSize(2);


### PR DESCRIPTION
### 요약
- 진행중인 캠페인 조회에서 전체 캠페인 조회로 변경
- 캠페인 반환 데이터에 캠페인의 상태값 추가
- 전체 캠페인 조회로의 테스트 변경