### PR TITLE
fix: 기본 배송지 설정에 따른 에러 처리

### DIFF
--- a/src/main/java/cholog/wiseshop/api/address/controller/AddressController.java
+++ b/src/main/java/cholog/wiseshop/api/address/controller/AddressController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,13 +27,6 @@ public class AddressController {
         this.addressService = addressService;
     }
 
-    @GetMapping
-    public ResponseEntity<List<AddressResponse>> createAddress(
-        @Auth Member member
-    ) {
-        return ResponseEntity.ok().body(addressService.getAll(member));
-    }
-
     @PostMapping
     public ResponseEntity<Long> createAddress(
         @Auth Member member,
@@ -40,6 +34,22 @@ public class AddressController {
     ) {
         Long response = addressService.createAddress(member, request);
         return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<AddressResponse>> readMemberAddresses(
+        @Auth Member member
+    ) {
+        return ResponseEntity.ok().body(addressService.getMemberAddresses(member));
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<Void> updateAddressDefault(
+        @Auth Member member,
+        Long id
+    ) {
+        addressService.updateAddress(member, id);
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/cholog/wiseshop/api/address/service/AddressService.java
+++ b/src/main/java/cholog/wiseshop/api/address/service/AddressService.java
@@ -48,7 +48,7 @@ public class AddressService {
     public void updateAddress(Member member, Long addressId) {
         Address targetAddress = addressRepository.findById(addressId)
             .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.ADDRESS_NOT_FOUND));
-        if (targetAddress.isOwner(member)) {
+        if (!targetAddress.isOwner(member)) {
             throw new WiseShopException(WiseShopErrorCode.NOT_OWNER);
         }
         Address currentDefaultAddress = addressRepository.findAllByMemberId(member.getId())

--- a/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
@@ -42,7 +42,7 @@ public class CampaignController {
 
     @GetMapping
     public ResponseEntity<List<ReadCampaignResponse>> readAllCampaign() {
-        var response = campaignService.readInProgressCampaign();
+        var response = campaignService.readAllCampaign();
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/cholog/wiseshop/api/campaign/dto/response/ReadCampaignResponse.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/dto/response/ReadCampaignResponse.java
@@ -1,6 +1,7 @@
 package cholog.wiseshop.api.campaign.dto.response;
 
 import cholog.wiseshop.api.product.dto.response.ProductResponse;
+import cholog.wiseshop.db.campaign.CampaignState;
 
 public record ReadCampaignResponse(
     Long campaignId,
@@ -9,6 +10,7 @@ public record ReadCampaignResponse(
     int goalQuantity,
     int orderedQuantity,
     int stockQuantity,
+    CampaignState state,
     ProductResponse product,
     Long ownerId
 ) {

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -90,13 +90,14 @@ public class CampaignService {
             findCampaign.getEndDate().toString(), findCampaign.getGoalQuantity(),
             findCampaign.getSoldQuantity(),
             findProduct.getStock().getTotalQuantity(),
+            findCampaign.getState(),
             new ProductResponse(findProduct),
             findCampaign.getMember().getId()
         );
     }
 
-    public List<ReadCampaignResponse> readInProgressCampaign() {
-        List<Campaign> campaigns = campaignRepository.findAllByState(CampaignState.IN_PROGRESS);
+    public List<ReadCampaignResponse> readAllCampaign() {
+        List<Campaign> campaigns = campaignRepository.findAll();
         return campaigns.stream()
             .map(campaign -> {
                 Product product = productRepository.findAllByCampaign(campaign).getFirst();
@@ -107,6 +108,7 @@ public class CampaignService {
                     campaign.getGoalQuantity(),
                     campaign.getSoldQuantity(),
                     product.getStock().getTotalQuantity(),
+                    campaign.getState(),
                     new ProductResponse(product),
                     campaign.getMember().getId()
                 );

--- a/src/main/java/cholog/wiseshop/db/address/Address.java
+++ b/src/main/java/cholog/wiseshop/db/address/Address.java
@@ -2,6 +2,8 @@ package cholog.wiseshop.db.address;
 
 import cholog.wiseshop.api.address.dto.request.CreateAddressRequest;
 import cholog.wiseshop.db.member.Member;
+import cholog.wiseshop.exception.WiseShopErrorCode;
+import cholog.wiseshop.exception.WiseShopException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -89,5 +91,9 @@ public class Address {
             request.isDefault(),
             member
         );
+    }
+
+    public void setDefault(boolean isDefault) {
+        this.isDefault = isDefault;
     }
 }

--- a/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
+++ b/src/main/java/cholog/wiseshop/exception/WiseShopErrorCode.java
@@ -9,6 +9,7 @@ public enum WiseShopErrorCode {
     MEMBER_INPROGRESS_CAMPAIGN_EXIST("회원의 진행 중인 캠페인이 존재합니다."),
     ADDRESS_NOT_FOUND("회원의 배송지 정보가 존재하지 않습니다."),
     ADDRESS_EXIST_INTO_ORDER("주문 중인 상품에 등록된 배송 정보가 존재합니다."),
+    DEFAULT_ADDRESS_NOT_DELETE("기본 설정된 배송 정보는 삭제가 불가능합니다."),
     PRODUCT_NOT_FOUND("상품이 존재하지 않습니다."),
     MODIFY_NAME_DESCRIPTION_PRODUCT_NOT_FOUND("이름 및 설명글 수정할 상품이 존재하지 않습니다."),
     MODIFY_PRICE_PRODUCT_NOT_FOUND("가격 수정할 상품이 존재하지 않습니다."),

--- a/src/test/java/cholog/wiseshop/domain/AddressServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/AddressServiceTest.java
@@ -110,6 +110,21 @@ class AddressServiceTest extends BaseTest {
         }
 
         @Test
+        void 자신의_배송지가_아닌_다른_배송지를_삭제하면_예외() {
+            // given
+            Member junho = MemberFixture.최준호();
+            Member june = MemberFixture.김준수();
+            memberRepository.saveAll(List.of(june, junho));
+            Address address = AddressFixture.집주소(junho);
+            addressRepository.save(address);
+
+            // when & then
+            assertThatThrownBy(() -> addressService.deleteAddress(june, address.getId()))
+                .isInstanceOf(WiseShopException.class)
+                .hasMessage(WiseShopErrorCode.NOT_OWNER.getMessage());
+        }
+
+        @Test
         void 기본_배송지를_삭제하면_예외() {
             // given
             Member member = MemberFixture.최준호();

--- a/src/test/java/cholog/wiseshop/domain/AddressServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/AddressServiceTest.java
@@ -83,7 +83,7 @@ class AddressServiceTest extends BaseTest {
             addressRepository.saveAll(List.of(home, company));
 
             // when
-            List<AddressResponse> response = addressService.getAll(member);
+            List<AddressResponse> response = addressService.getMemberAddresses(member);
 
             // then
             assertThat(response).hasSize(2);
@@ -94,18 +94,33 @@ class AddressServiceTest extends BaseTest {
     class 사용자가_배송지를_삭제한다 {
 
         @Test
-        void 사용자가_배송지를_정상적으로_삭제한다() {
+        void 사용자가_기본_배송지가_아닌_다른_배송지를_정상적으로_삭제한다() {
+            // given
+            Member member = MemberFixture.최준호();
+            memberRepository.save(member);
+            Address home = AddressFixture.집주소(member);
+            Address company = AddressFixture.회사주소(member);
+            addressRepository.saveAll(List.of(home, company));
+
+            // when
+            addressService.deleteAddress(member, company.getId());
+
+            // then
+            assertThat(addressRepository.findById(company.getId())).isEmpty();
+        }
+
+        @Test
+        void 기본_배송지를_삭제하면_예외() {
             // given
             Member member = MemberFixture.최준호();
             memberRepository.save(member);
             Address address = AddressFixture.집주소(member);
             addressRepository.save(address);
 
-            // when
-            addressService.deleteAddress(member, address.getId());
-
-            // then
-            assertThat(addressRepository.findById(address.getId())).isEmpty();
+            // when & then
+            assertThatThrownBy(() -> addressService.deleteAddress(member, address.getId()))
+                .isInstanceOf(WiseShopException.class)
+                .hasMessage(WiseShopErrorCode.DEFAULT_ADDRESS_NOT_DELETE.getMessage());
         }
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/CampaignServiceTest.java
@@ -183,7 +183,7 @@ public class CampaignServiceTest extends BaseTest {
         }
 
         @Test
-        void 캠페인_전체조회_시_진행중_캠페인들만_조회() {
+        void 캠페인_전체조회_성공적으로_조회() {
             // given
             Member member = memberRepository.save(MemberFixture.최준호());
             LocalDateTime now = LocalDateTime.now();
@@ -231,7 +231,7 @@ public class CampaignServiceTest extends BaseTest {
             List<ReadCampaignResponse> response = campaignService.readAllCampaign();
 
             // then
-            assertThat(response).hasSize(2);
+            assertThat(response).hasSize(3);
         }
 
         @Test

--- a/src/test/java/cholog/wiseshop/domain/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/CampaignServiceTest.java
@@ -228,7 +228,7 @@ public class CampaignServiceTest extends BaseTest {
             productRepository.saveAll(List.of(productA, productB, productC));
 
             // when
-            List<ReadCampaignResponse> response = campaignService.readInProgressCampaign();
+            List<ReadCampaignResponse> response = campaignService.readAllCampaign();
 
             // then
             assertThat(response).hasSize(2);


### PR DESCRIPTION
### 요약
- 기본 배송지 1개만 설정 가능하도록 구현
   - 생성을 진행할 때 애초에 기본 배송지가 존재하면 무조건적으로 `isDefault`를 `false`로 지정
   - 따라서 기본 배송지 변경이라는 API를 따로 구현함
- 기본 배송지는 삭제 불가능
   - 기존에는 기본 배송지도 삭제가 가능했으나 삭제가 불가능 하도록 변경