### PR TITLE
refactor: 캠페인이 종료(성공, 실패)된 경우에도, 회원탈퇴가 가능하도록 변경

### DIFF
--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -8,7 +8,6 @@ import cholog.wiseshop.api.product.dto.response.ProductResponse;
 import cholog.wiseshop.common.ThreadTaskScheduler;
 import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.campaign.CampaignRepository;
-import cholog.wiseshop.db.campaign.CampaignState;
 import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.product.Product;
 import cholog.wiseshop.db.product.ProductRepository;
@@ -92,7 +91,7 @@ public class CampaignService {
             findProduct.getStock().getTotalQuantity(),
             findCampaign.getState(),
             new ProductResponse(findProduct),
-            findCampaign.getMember().getId()
+            findCampaign.getMember().orElse(Member.createEmpty()).getId()
         );
     }
 
@@ -110,7 +109,7 @@ public class CampaignService {
                     product.getStock().getTotalQuantity(),
                     campaign.getState(),
                     new ProductResponse(product),
-                    campaign.getMember().getId()
+                    campaign.getMember().orElse(Member.createEmpty()).getId()
                 );
             }).toList();
     }

--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -77,7 +77,7 @@ public class CampaignService {
     }
 
     public ReadCampaignResponse readCampaign(Long campaignId) {
-        List<Product> findProducts = productRepository.findProductsByCampaignId(campaignId);
+        List<Product> findProducts = productRepository.findAllByCampaignId(campaignId);
         if (findProducts.isEmpty()) {
             throw new WiseShopException(WiseShopErrorCode.CAMPAIGN_NOT_FOUND);
         }

--- a/src/main/java/cholog/wiseshop/api/member/service/MemberService.java
+++ b/src/main/java/cholog/wiseshop/api/member/service/MemberService.java
@@ -41,7 +41,7 @@ public class MemberService {
 
     public void deleteMember(Member member) {
         Long memberId = member.getId();
-        List<Campaign> campaigns = campaignRepository.findCampaignByMemberId(memberId);
+        List<Campaign> campaigns = campaignRepository.findAllByMemberId(memberId);
         if (campaigns.stream().anyMatch(it -> it.getState().equals(CampaignState.IN_PROGRESS))) {
             throw new WiseShopException(WiseShopErrorCode.MEMBER_INPROGRESS_CAMPAIGN_EXIST);
         }
@@ -51,7 +51,7 @@ public class MemberService {
 
     private void setEmptyParent(Long memberId, List<Campaign> campaigns) {
         List<Product> products = productRepository.findByOwnerId(memberId);
-        List<Order> orders = orderRepository.findByMemberId(memberId);
+        List<Order> orders = orderRepository.findAllByMemberId(memberId);
         List<Address> addresses = addressRepository.findAllByMemberId(memberId);
 
         campaigns.forEach(c -> c.setMember(null));

--- a/src/main/java/cholog/wiseshop/api/member/service/MemberService.java
+++ b/src/main/java/cholog/wiseshop/api/member/service/MemberService.java
@@ -50,7 +50,7 @@ public class MemberService {
     }
 
     private void setEmptyParent(Long memberId, List<Campaign> campaigns) {
-        List<Product> products = productRepository.findByMemberId(memberId);
+        List<Product> products = productRepository.findAllByOwnerId(memberId);
         List<Order> orders = orderRepository.findAllByMemberId(memberId);
         List<Address> addresses = addressRepository.findAllByMemberId(memberId);
 

--- a/src/main/java/cholog/wiseshop/api/member/service/MemberService.java
+++ b/src/main/java/cholog/wiseshop/api/member/service/MemberService.java
@@ -54,9 +54,9 @@ public class MemberService {
         List<Order> orders = orderRepository.findAllByMemberId(memberId);
         List<Address> addresses = addressRepository.findAllByMemberId(memberId);
 
-        campaigns.forEach(c -> c.setMember(null));
-        products.forEach(p -> p.setOwner(null));
-        orders.forEach(o -> o.setMember(null));
-        addresses.forEach(a -> a.setMember(null));
+        campaigns.forEach(campaign -> campaign.setMember(null));
+        products.forEach(product -> product.setOwner(null));
+        orders.forEach(order -> order.setMember(null));
+        addresses.forEach(address -> address.setMember(null));
     }
 }

--- a/src/main/java/cholog/wiseshop/api/member/service/MemberService.java
+++ b/src/main/java/cholog/wiseshop/api/member/service/MemberService.java
@@ -50,7 +50,7 @@ public class MemberService {
     }
 
     private void setEmptyParent(Long memberId, List<Campaign> campaigns) {
-        List<Product> products = productRepository.findByOwnerId(memberId);
+        List<Product> products = productRepository.findByMemberId(memberId);
         List<Order> orders = orderRepository.findAllByMemberId(memberId);
         List<Address> addresses = addressRepository.findAllByMemberId(memberId);
 

--- a/src/main/java/cholog/wiseshop/api/order/dto/response/MemberOrderResponse.java
+++ b/src/main/java/cholog/wiseshop/api/order/dto/response/MemberOrderResponse.java
@@ -1,5 +1,6 @@
 package cholog.wiseshop.api.order.dto.response;
 
+import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.order.Order;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
@@ -20,7 +21,7 @@ public record MemberOrderResponse(
     public MemberOrderResponse(Order order) {
         this(
             order.getId(),
-            order.getMember().getId(),
+            order.getMember().orElse(Member.createEmpty()).getId(),
             order.getProduct().getId(),
             order.getProduct().getName(),
             order.getAddress(),

--- a/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
+++ b/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
@@ -61,7 +61,7 @@ public class OrderService {
 
     @Transactional(readOnly = true)
     public List<MemberOrderResponse> readMemberOrders(Member member) {
-        return orderRepository.findByMemberId(member.getId()).stream()
+        return orderRepository.findAllByMemberId(member.getId()).stream()
             .map(MemberOrderResponse::new)
             .toList();
     }

--- a/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
+++ b/src/main/java/cholog/wiseshop/api/order/service/OrderService.java
@@ -45,7 +45,7 @@ public class OrderService {
         validateCampaignStateInProgress(campaign);
         Stock stock = product.getStock();
         validateQuantity(campaign, stock, request.orderQuantity());
-        Member campaignOwner = campaign.getMember();
+        Member campaignOwner = campaign.getMember().orElse(Member.createEmpty());
         validateOrderOwner(campaignOwner, member);
         Order order = orderRepository.save(request.from(product, member, address));
         campaign.increaseSoldQuantity(request.orderQuantity());

--- a/src/main/java/cholog/wiseshop/api/product/dto/response/ProductResponse.java
+++ b/src/main/java/cholog/wiseshop/api/product/dto/response/ProductResponse.java
@@ -1,5 +1,6 @@
 package cholog.wiseshop.api.product.dto.response;
 
+import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.product.Product;
 
 public record ProductResponse(
@@ -14,7 +15,7 @@ public record ProductResponse(
     public ProductResponse(Product product) {
         this(
             product.getId(),
-            product.getOwner().getId(),
+            product.getOwner().orElse(Member.createEmpty()).getId(),
             product.getName(),
             product.getDescription(),
             product.getPrice(),

--- a/src/main/java/cholog/wiseshop/common/TestDataLoader.java
+++ b/src/main/java/cholog/wiseshop/common/TestDataLoader.java
@@ -1,0 +1,73 @@
+
+ package cholog.wiseshop.common;
+
+import cholog.wiseshop.db.campaign.Campaign;
+import cholog.wiseshop.db.campaign.CampaignRepository;
+import cholog.wiseshop.db.campaign.CampaignState;
+import cholog.wiseshop.db.member.Member;
+import cholog.wiseshop.db.member.MemberRepository;
+import cholog.wiseshop.db.product.Product;
+import cholog.wiseshop.db.product.ProductRepository;
+import cholog.wiseshop.db.stock.Stock;
+import cholog.wiseshop.db.stock.StockRepository;
+import java.time.LocalDateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Profile("local")
+@Component
+public class TestDataLoader implements CommandLineRunner {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    CampaignRepository campaignRepository;
+
+    @Autowired
+    ProductRepository productRepository;
+
+    @Autowired
+    StockRepository stockRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(String... args) throws Exception {
+        Member supplier = memberRepository.save(new Member(
+            "supplier@test.com",
+            "판매자",
+            passwordEncoder.encode("12341234")
+        ));
+        memberRepository.save(new Member(
+            "customer@test.com",
+            "구매자",
+            passwordEncoder.encode("12341234")
+        ));
+        LocalDateTime now = LocalDateTime.now();
+        Campaign campaign = campaignRepository.save(Campaign.builder()
+            .startDate(now.plusDays(1))
+            .endDate(now.plusDays(2))
+            .goalQuantity(100)
+            .soldQuantity(0)
+            .state(CampaignState.IN_PROGRESS)
+            .member(supplier)
+            .now(now)
+            .build()
+        );
+        Stock stock = stockRepository.save(new Stock(500));
+        productRepository.save(Product.builder()
+            .name("에그타르트")
+            .description("에그타르트 맛있어요")
+            .price(5000)
+            .stock(stock)
+            .campaign(campaign)
+            .owner(supplier)
+            .build()
+        );
+    }
+}

--- a/src/main/java/cholog/wiseshop/db/address/Address.java
+++ b/src/main/java/cholog/wiseshop/db/address/Address.java
@@ -55,7 +55,7 @@ public class Address {
     }
 
     public boolean isOwner(Member member) {
-        return Objects.equals(getMember().orElse(Member.createEmpty()), member.getId());
+        return Objects.equals(getMember().orElse(Member.createEmpty()).getId(), member.getId());
     }
 
     public Long getId() {

--- a/src/main/java/cholog/wiseshop/db/address/Address.java
+++ b/src/main/java/cholog/wiseshop/db/address/Address.java
@@ -2,8 +2,6 @@ package cholog.wiseshop.db.address;
 
 import cholog.wiseshop.api.address.dto.request.CreateAddressRequest;
 import cholog.wiseshop.db.member.Member;
-import cholog.wiseshop.exception.WiseShopErrorCode;
-import cholog.wiseshop.exception.WiseShopException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -14,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.util.Objects;
+import java.util.Optional;
 
 @Table(name = "ADDRESS")
 @Entity
@@ -56,7 +55,7 @@ public class Address {
     }
 
     public boolean isOwner(Member member) {
-        return Objects.equals(getMember().getId(), member.getId());
+        return Objects.equals(getMember().orElse(Member.createEmpty()), member.getId());
     }
 
     public Long getId() {
@@ -79,8 +78,8 @@ public class Address {
         return isDefault;
     }
 
-    public Member getMember() {
-        return member;
+    public Optional<Member> getMember() {
+        return Optional.ofNullable(member);
     }
 
     public static Address from(Member member, CreateAddressRequest request) {
@@ -95,5 +94,9 @@ public class Address {
 
     public void setDefault(boolean isDefault) {
         this.isDefault = isDefault;
+    }
+
+    public void setMember(Member member) {
+        this.member = member;
     }
 }

--- a/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/Campaign.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Table;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Objects;
+import java.util.Optional;
 
 @Table(name = "campaign")
 @Entity
@@ -90,6 +91,10 @@ public class Campaign {
         } else {
             state = CampaignState.SUCCESS;
         }
+    }
+
+    public void setMember(Member member) {
+        this.member = member;
     }
 
     public static CampaignBuilder builder() {
@@ -191,8 +196,8 @@ public class Campaign {
         return state;
     }
 
-    public Member getMember() {
-        return member;
+    public Optional<Member> getMember() {
+        return Optional.ofNullable(member);
     }
 
     public boolean isInProgress() {

--- a/src/main/java/cholog/wiseshop/db/campaign/CampaignRepository.java
+++ b/src/main/java/cholog/wiseshop/db/campaign/CampaignRepository.java
@@ -6,10 +6,8 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface CampaignRepository extends JpaRepository<Campaign, Long> {
 
-    List<Campaign> findCampaignByMemberId(Long memberId);
+    List<Campaign> findAllByMemberId(Long memberId);
 
     @Query("SELECT c FROM Campaign c WHERE c.state IN :states")
     List<Campaign> findAllByStates(List<CampaignState> states);
-
-    List<Campaign> findAllByState(CampaignState campaignState);
 }

--- a/src/main/java/cholog/wiseshop/db/member/Member.java
+++ b/src/main/java/cholog/wiseshop/db/member/Member.java
@@ -28,6 +28,10 @@ public class Member {
     @Column(name = "password", nullable = false)
     private String password;
 
+    public static Member createEmpty() {
+        return new Member();
+    }
+
     public Member(
         String email,
         String name,

--- a/src/main/java/cholog/wiseshop/db/order/Order.java
+++ b/src/main/java/cholog/wiseshop/db/order/Order.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.util.Objects;
+import java.util.Optional;
 
 @Table(name = "`order`")
 @Entity
@@ -53,7 +54,11 @@ public class Order extends BaseTimeEntity {
     }
 
     public boolean isOwner(Member member) {
-        return Objects.equals(getMember().getId(), member.getId());
+        return Objects.equals(getMember().orElse(Member.createEmpty()), member.getId());
+    }
+
+    public void setMember(Member member) {
+        this.member = member;
     }
 
     public static final class OrderBuilder {
@@ -108,8 +113,8 @@ public class Order extends BaseTimeEntity {
         return count;
     }
 
-    public Member getMember() {
-        return member;
+    public Optional<Member> getMember() {
+        return Optional.ofNullable(member);
     }
 
     public String getAddress() {

--- a/src/main/java/cholog/wiseshop/db/order/Order.java
+++ b/src/main/java/cholog/wiseshop/db/order/Order.java
@@ -54,7 +54,7 @@ public class Order extends BaseTimeEntity {
     }
 
     public boolean isOwner(Member member) {
-        return Objects.equals(getMember().orElse(Member.createEmpty()), member.getId());
+        return Objects.equals(getMember().orElse(Member.createEmpty()).getId(), member.getId());
     }
 
     public void setMember(Member member) {

--- a/src/main/java/cholog/wiseshop/db/order/OrderRepository.java
+++ b/src/main/java/cholog/wiseshop/db/order/OrderRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
-    List<Order> findByMemberId(Long memberId);
+    List<Order> findAllByMemberId(Long memberId);
     Optional<Order> findByIdAndMemberId(Long id, Long memberId);
-    List<Order> findAllByProductId(Long productId);
 }

--- a/src/main/java/cholog/wiseshop/db/product/Product.java
+++ b/src/main/java/cholog/wiseshop/db/product/Product.java
@@ -15,6 +15,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.util.Objects;
+import java.util.Optional;
 
 @Table(name = "product")
 @Entity
@@ -63,6 +64,10 @@ public class Product {
 
     public static ProductBuilder builder() {
         return new ProductBuilder();
+    }
+
+    public void setOwner(Member owner) {
+        this.owner = owner;
     }
 
     public static final class ProductBuilder {
@@ -160,7 +165,7 @@ public class Product {
         return stock;
     }
 
-    public Member getOwner() {
-        return owner;
+    public Optional<Member> getOwner() {
+        return Optional.ofNullable(owner);
     }
 }

--- a/src/main/java/cholog/wiseshop/db/product/ProductRepository.java
+++ b/src/main/java/cholog/wiseshop/db/product/ProductRepository.java
@@ -13,5 +13,5 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     List<Product> findAllByCampaign(Campaign campaign);
 
-    List<Product> findByMemberId(Long memberId);
+    List<Product> findAllByOwnerId(Long memberId);
 }

--- a/src/main/java/cholog/wiseshop/db/product/ProductRepository.java
+++ b/src/main/java/cholog/wiseshop/db/product/ProductRepository.java
@@ -9,9 +9,9 @@ import org.springframework.data.repository.query.Param;
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
     @Query("SELECT p FROM Product p JOIN FETCH p.stock JOIN FETCH p.campaign WHERE p.campaign.id = :campaignId")
-    List<Product> findProductsByCampaignId(@Param("campaignId") Long campaignId);
+    List<Product> findAllByCampaignId(@Param("campaignId") Long campaignId);
 
     List<Product> findAllByCampaign(Campaign campaign);
 
-    List<Product> findByOwnerId(Long memberId);
+    List<Product> findByMemberId(Long memberId);
 }

--- a/src/main/java/cholog/wiseshop/db/product/ProductRepository.java
+++ b/src/main/java/cholog/wiseshop/db/product/ProductRepository.java
@@ -12,4 +12,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> findProductsByCampaignId(@Param("campaignId") Long campaignId);
 
     List<Product> findAllByCampaign(Campaign campaign);
+
+    List<Product> findByOwnerId(Long memberId);
 }

--- a/src/test/java/cholog/wiseshop/domain/AddressServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/AddressServiceTest.java
@@ -136,6 +136,8 @@ class AddressServiceTest extends BaseTest {
             List<Address> addresses = addressRepository.saveAll(List.of(home, company));
 
             // when
+            System.out.println(member.getName());
+            System.out.println(addresses.getLast().getMember().get().getName());
             addressService.updateAddress(member, addresses.getLast().getId());
             Address address = addressRepository.findById(addresses.getLast().getId())
                 .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.ADDRESS_NOT_FOUND));

--- a/src/test/java/cholog/wiseshop/domain/MemberServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/MemberServiceTest.java
@@ -7,14 +7,24 @@ import cholog.wiseshop.api.member.dto.request.SignUpRequest;
 import cholog.wiseshop.api.member.service.AuthService;
 import cholog.wiseshop.api.member.service.MemberService;
 import cholog.wiseshop.common.BaseTest;
+import cholog.wiseshop.db.address.Address;
+import cholog.wiseshop.db.address.AddressRepository;
 import cholog.wiseshop.db.campaign.Campaign;
 import cholog.wiseshop.db.campaign.CampaignRepository;
+import cholog.wiseshop.db.campaign.CampaignState;
 import cholog.wiseshop.db.member.Member;
 import cholog.wiseshop.db.member.MemberRepository;
+import cholog.wiseshop.db.order.Order;
+import cholog.wiseshop.db.order.OrderRepository;
+import cholog.wiseshop.db.product.Product;
+import cholog.wiseshop.db.product.ProductRepository;
 import cholog.wiseshop.exception.WiseShopErrorCode;
 import cholog.wiseshop.exception.WiseShopException;
+import cholog.wiseshop.fixture.AddressFixture;
 import cholog.wiseshop.fixture.CampaignFixture;
 import cholog.wiseshop.fixture.MemberFixture;
+import cholog.wiseshop.fixture.OrderFixture;
+import cholog.wiseshop.fixture.ProductFixture;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +37,15 @@ class MemberServiceTest extends BaseTest {
 
     @Autowired
     private CampaignRepository campaignRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private AddressRepository addressRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
 
     @Autowired
     private AuthService authService;
@@ -100,6 +119,60 @@ class MemberServiceTest extends BaseTest {
             assertThatThrownBy(() -> memberService.deleteMember(member))
                 .isInstanceOf(WiseShopException.class)
                 .hasMessage(WiseShopErrorCode.MEMBER_INPROGRESS_CAMPAIGN_EXIST.getMessage());
+        }
+
+        @Test
+        void 성공한_캠페인이_존재하면_정상수행() {
+            // given
+            Member member = MemberFixture.최준호();
+            Campaign campaign = CampaignFixture.종료된_보약_캠페인(member, CampaignState.SUCCESS);
+            Product product = ProductFixture.캠페인의_보약(campaign, member);
+            Address address = AddressFixture.집주소(member);
+            Order order = OrderFixture.주문하기(product, member, address);
+
+            memberRepository.save(member);
+            campaignRepository.save(campaign);
+            productRepository.save(product);
+            addressRepository.save(address);
+            orderRepository.save(order);
+
+            // when
+            memberService.deleteMember(member);
+
+            // then
+            assertThat(memberRepository.findById(member.getId())).isEmpty();
+
+            assertThat(campaignRepository.findById(campaign.getId())).isNotEmpty();
+            assertThat(productRepository.findById(product.getId())).isNotEmpty();
+            assertThat(addressRepository.findById(address.getId())).isNotEmpty();
+            assertThat(orderRepository.findById(order.getId())).isNotEmpty();
+        }
+
+        @Test
+        void 실패한_캠페인이_존재하면_정상수행() {
+            // given
+            Member member = MemberFixture.최준호();
+            Campaign campaign = CampaignFixture.종료된_보약_캠페인(member, CampaignState.FAILED );
+            Product product = ProductFixture.캠페인의_보약(campaign, member);
+            Address address = AddressFixture.집주소(member);
+            Order order = OrderFixture.주문하기(product, member, address);
+
+            memberRepository.save(member);
+            campaignRepository.save(campaign);
+            productRepository.save(product);
+            addressRepository.save(address);
+            orderRepository.save(order);
+
+            // when
+            memberService.deleteMember(member);
+
+            // then
+            assertThat(memberRepository.findById(member.getId())).isEmpty();
+
+            assertThat(campaignRepository.findById(campaign.getId())).isNotEmpty();
+            assertThat(productRepository.findById(product.getId())).isNotEmpty();
+            assertThat(addressRepository.findById(address.getId())).isNotEmpty();
+            assertThat(orderRepository.findById(order.getId())).isNotEmpty();
         }
     }
 }

--- a/src/test/java/cholog/wiseshop/domain/OrderServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/OrderServiceTest.java
@@ -85,7 +85,7 @@ class OrderServiceTest extends BaseTest {
             orderService.createOrder(request, junesoo);
 
             // then
-            assertThat(orderRepository.findByMemberId(junesoo.getId())).isNotEmpty();
+            assertThat(orderRepository.findAllByMemberId(junesoo.getId())).isNotEmpty();
         }
 
         @Test

--- a/src/test/java/cholog/wiseshop/fixture/CampaignFixture.java
+++ b/src/test/java/cholog/wiseshop/fixture/CampaignFixture.java
@@ -46,4 +46,17 @@ public class CampaignFixture {
             .now(now)
             .build();
     }
+
+    public static Campaign 종료된_보약_캠페인(Member member, CampaignState state) {
+        LocalDateTime now = LocalDateTime.now();
+        return Campaign.builder()
+            .startDate(now.plusDays(1))
+            .endDate(now.plusDays(2))
+            .goalQuantity(100)
+            .soldQuantity(0)
+            .state(state)
+            .member(member)
+            .now(now)
+            .build();
+    }
 }


### PR DESCRIPTION
## 요약
- 로컬환경에서의 원활한 테스트를 위해, `local` 프로필로 실행 시, 테스트 데이터가 추가되도록 구현
- `Member`를 참조하는 `Address`, `Campaign`, `Product`, `Order`가 `Member`가 삭제되기 전 Null 값을 갖도록 하는 `setter` 추가
 - `memberService.deletebyMemberId()`를 호출하여 `Member`가 영속상태가 아니게 되었을 때, `Member`를 참조하는 `Campaign` 등 자식 객체에서 발생하는 `TransientObjectException` 문제 해결

### 에러 발생 원인
```java
    public void deleteMember(Member member) {
        // 2. 영속 상태를 갖지 않는 Member를 참조하는 Campaign으로 인해 TransientObjectException 발생
        List<Campaign> campaigns = campaignRepository.findCampaignByMemberId(member.getId());
        if (campaigns.stream().anyMatch(it -> it.getState().equals(CampaignState.IN_PROGRESS))) {
            throw new WiseShopException(WiseShopErrorCode.MEMBER_INPROGRESS_CAMPAIGN_EXIST);
        }
        memberRepository.deleteById(member.getId()); // 1. 커밋 후, Member는 영속 상태를 갖지 않는다.
    }
```
`org.hibernate.TransientObjectException: persistent instance references an unsaved transient instance of 'cholog.wiseshop.db.member.Member' (save the transient instance before flushing)` 

### `Member`를 갖는 [자식 객체가 Null을 참조](https://github.com/cholog-project/wiseshop/commit/4c0b74475b7bc9bf6b506eb09c8854bf94d4242d#diff-2853913a02d9b715a98e377313cabb82f006254beebcebc2f5520009728fd11cR52-R60)하도록 한 이유
<img width="1169" alt="delete 쿼리 실행 시, 참조 무결성 제약조건 위반 에러 (캠페인의 연관관계 null 설정시)" src="https://github.com/user-attachments/assets/d5900733-52cf-497f-bacc-1f6e65187df2" />

이는 `campaign.setMember(null)`을 호출하더라도 `member`의 FK를 갖는 `product`로 인해 참조 무결성 제약조건 위반 예외가 발생합니다. 따라서 `setEmptyParent`를 호출해서 FK가 null 값을 갖도록 했습니다.

## 변경 결과
- 성공하거나 실패한 캠페인만 갖는 회원도 탈퇴가 가능
- 회원이 탈퇴하여도 연관된 모든 정보는 존재
