### PR TITLE
feat: 100만건의 데이터 생성을 위한 API 구현

### DIFF
--- a/src/main/java/cholog/wiseshop/api/testdata/controller/TestDataController.java
+++ b/src/main/java/cholog/wiseshop/api/testdata/controller/TestDataController.java
@@ -1,0 +1,30 @@
+package cholog.wiseshop.api.testdata.controller;
+
+import cholog.wiseshop.api.testdata.service.TestDataService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v1")
+@RestController
+public class TestDataController {
+
+    private final TestDataService testDataService;
+
+    public TestDataController(TestDataService testDataService) {
+        this.testDataService = testDataService;
+    }
+
+    @PostMapping("/test/generate/test-member")
+    public ResponseEntity<Void> generateTestMember() {
+        testDataService.generateTestMember();
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/test/generate/test-campaign")
+    public ResponseEntity<Void> generateCampaign() {
+        testDataService.generateTestData();
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/cholog/wiseshop/api/testdata/service/TestDataService.java
+++ b/src/main/java/cholog/wiseshop/api/testdata/service/TestDataService.java
@@ -34,7 +34,6 @@ public class TestDataService {
 
     public void generateTestMember() {
         cleanAllData();
-        generateTestMemberData(1);
         generateTestMemberData(TEST_MEMBER_SIZE);
     }
 

--- a/src/main/java/cholog/wiseshop/api/testdata/service/TestDataService.java
+++ b/src/main/java/cholog/wiseshop/api/testdata/service/TestDataService.java
@@ -1,0 +1,212 @@
+package cholog.wiseshop.api.testdata.service;
+
+import cholog.wiseshop.common.DatabaseCleaner;
+import cholog.wiseshop.db.campaign.CampaignState;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+public class TestDataService {
+
+    private static final int TEST_MEMBER_SIZE = 1_000_000;
+    private static final int TEST_CAMPAIGN_SIZE = 1_000_000;
+    private static final int TEST_PRODUCT_SIZE = 1_000_000;
+    private static final int TEST_STOCK_SIZE = 1_000_000;
+    private static final int TEST_ORDER_SIZE = 1_000_000;
+    private static final int BATCH_SIZE = 10_000;
+
+    private final DatabaseCleaner databaseCleaner;
+    private final JdbcTemplate jdbcTemplate;
+
+    public TestDataService(
+        DatabaseCleaner databaseCleaner,
+        JdbcTemplate jdbcTemplate
+    ) {
+        this.databaseCleaner = databaseCleaner;
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public void generateTestMember() {
+        cleanAllData();
+        generateTestMemberData(1);
+        generateTestMemberData(TEST_MEMBER_SIZE);
+    }
+
+    public void generateTestData() {
+        cleanAllData();
+        generateTestMemberData(2);
+        generateTestCampaignData(TEST_CAMPAIGN_SIZE);
+        generateTestStockData(TEST_STOCK_SIZE);
+        generateTestProductData(TEST_PRODUCT_SIZE);
+        generateTestOrderData(TEST_ORDER_SIZE);
+    }
+
+    public void generateTestMemberData(int size) {
+        String sql = "INSERT INTO member (email, name, password) VALUES (?, ?, ?)";
+        List<Object[]> memberBatch = new ArrayList<>();
+
+        for (int i = 1; i <= size; i++) {
+            String email = "test" + i + "@test.com";
+            String name = "test-" + UUID.randomUUID().toString().substring(0, 10);
+            String password = "$2a$10$C5.NxKqjo2FC72RjSWJj1uNtCbia5ClEY5KhMtO7jEUN6N5s3.ZVu";
+
+            memberBatch.add(new Object[]{email, name, password});
+
+            if (memberBatch.size() % BATCH_SIZE == 0) {
+                batchTestMember(sql, memberBatch);
+            }
+        }
+
+        if (!memberBatch.isEmpty()) {
+            batchTestMember(sql, memberBatch);
+        }
+    }
+
+    public void generateTestStockData(int size) {
+        String sql = "INSERT INTO stock (total_quantity) VALUES (?)";
+        List<Object[]> stockBatch = new ArrayList<>();
+
+        for (int i = 1; i <= size; i++) {
+            int totalQuantity = 100;
+
+            stockBatch.add(new Object[]{totalQuantity});
+
+            if (stockBatch.size() % BATCH_SIZE == 0) {
+                batchTestMember(sql, stockBatch);
+            }
+        }
+
+        if (!stockBatch.isEmpty()) {
+            batchTestMember(sql, stockBatch);
+        }
+    }
+
+    public void generateTestCampaignData(int size) {
+        String sql = "INSERT INTO "
+            + "campaign (start_date, end_date, goal_quantity, sold_quantity, state, member_id) "
+            + "VALUES (?, ?, ?, ?, ?, ?)";
+        List<Object[]> campaignBatch = new ArrayList<>();
+        Long memberId = getTestDataIds("member", 1).getFirst();
+
+        for (int i = 1; i <= size; i++) {
+            LocalDateTime now = LocalDateTime.now();
+
+            LocalDateTime startDate = now.minusDays(1);
+            LocalDateTime endDate = now.plusMinutes(10);
+            int goalQuantity = 10;
+            int soldQuantity = 0;
+            String state = CampaignState.IN_PROGRESS.toString();
+
+            campaignBatch.add(new Object[]{
+                startDate,
+                endDate,
+                goalQuantity,
+                soldQuantity,
+                state,
+                memberId
+            });
+
+            if (campaignBatch.size() % BATCH_SIZE == 0) {
+                batchTestMember(sql, campaignBatch);
+            }
+        }
+
+        if (!campaignBatch.isEmpty()) {
+            batchTestMember(sql, campaignBatch);
+        }
+    }
+
+    public void generateTestProductData(int size) {
+        String sql = "INSERT INTO "
+            + "product (name, description, price, campaign_id, stock_id, member_id) "
+            + "VALUES (?, ?, ?, ?, ?, ?)";
+        List<Object[]> productBatch = new ArrayList<>();
+        List<Long> campaignIds = getTestDataIds("campaign", size);
+        List<Long> stockIds = getTestDataIds("stock", size);
+        Long memberId = getTestDataIds("member", 1).getFirst();
+
+        for (int i = 1; i <= size; i++) {
+            String name = "Test Product-" + UUID.randomUUID().toString().substring(0, 5);
+            String description = "Test Description" + UUID.randomUUID().toString().substring(0, 10);
+            int price = (int) (Math.random() * 100) + 10000;
+            Long campaignId = campaignIds.get(i - 1);
+            Long stockId = stockIds.get(i - 1);
+
+            productBatch.add(new Object[]{
+                name,
+                description,
+                price,
+                campaignId,
+                stockId,
+                memberId
+            });
+
+            if (productBatch.size() % BATCH_SIZE == 0) {
+                batchTestMember(sql, productBatch);
+            }
+        }
+
+        if (!productBatch.isEmpty()) {
+            batchTestMember(sql, productBatch);
+        }
+    }
+
+    public void generateTestOrderData(int size) {
+        String sql = "INSERT INTO "
+            + "`order` (count, product_id, member_id, address, created_date, modified_date) "
+            + "VALUES (?, ?, ?, ?, ?, ?)";
+        List<Object[]> orderBatch = new ArrayList<>();
+        List<Long> productIds = getTestDataIds("product", size);
+        Long memberId = getTestDataIds("member", size).getLast();
+
+        for (int i = 1; i <= size; i++) {
+            int count = 1;
+            Long productId = productIds.get(i - 1);
+            LocalDateTime createdDate = LocalDateTime.now();
+            LocalDateTime modifiedDate = LocalDateTime.now();
+            String address = "테스트 집-" + UUID.randomUUID().toString().substring(0, 10);
+
+            orderBatch.add(new Object[]{
+                count,
+                productId,
+                memberId,
+                address,
+                createdDate,
+                modifiedDate
+            });
+
+            if (orderBatch.size() % BATCH_SIZE == 0) {
+                batchTestMember(sql, orderBatch);
+            }
+        }
+
+        if (!orderBatch.isEmpty()) {
+            batchTestMember(sql, orderBatch);
+        }
+    }
+
+    public void batchTestMember(String sql, List<Object[]> batchArgs) {
+        jdbcTemplate.batchUpdate(sql, batchArgs);
+        batchArgs.clear();
+    }
+
+    public List<Long> getTestDataIds(String tableName, int limitLength) {
+        return jdbcTemplate.queryForList(
+            "SELECT id FROM "
+                + tableName
+                + " LIMIT "
+                + limitLength,
+            Long.class
+        );
+    }
+
+    public void cleanAllData() {
+        databaseCleaner.clear();
+    }
+}

--- a/src/main/java/cholog/wiseshop/common/DatabaseCleaner.java
+++ b/src/main/java/cholog/wiseshop/common/DatabaseCleaner.java
@@ -1,0 +1,46 @@
+package cholog.wiseshop.common;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Table;
+import jakarta.persistence.metamodel.EntityType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class DatabaseCleaner {
+
+    private final List<String> tableNames = new ArrayList<>();
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @PostConstruct
+    private void findDatabaseTableNames() {
+        Set<EntityType<?>> entities = entityManager.getMetamodel().getEntities();
+        for (EntityType<?> entity : entities) {
+            Table tableAnnotation = entity.getJavaType().getAnnotation(Table.class);
+            String tableName = tableAnnotation != null ? tableAnnotation.name() : entity.getName();
+            tableNames.add(tableName);
+        }
+    }
+
+    @Transactional
+    public void clear() {
+        entityManager.clear();
+        try {
+            entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
+            for (String tableName : tableNames) {
+                entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+            }
+            entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
+            entityManager.flush();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to clean database: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/cholog/wiseshop/db/address/Address.java
+++ b/src/main/java/cholog/wiseshop/db/address/Address.java
@@ -14,7 +14,7 @@ import jakarta.persistence.Table;
 import java.util.Objects;
 import java.util.Optional;
 
-@Table(name = "ADDRESS")
+@Table(name = "address")
 @Entity
 public class Address {
 

--- a/src/main/java/cholog/wiseshop/db/member/Member.java
+++ b/src/main/java/cholog/wiseshop/db/member/Member.java
@@ -8,7 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 
-@Table(name = "MEMBER")
+@Table(name = "member")
 @Entity
 public class Member {
 

--- a/src/main/java/cholog/wiseshop/db/stock/Stock.java
+++ b/src/main/java/cholog/wiseshop/db/stock/Stock.java
@@ -8,7 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
-@Table(name = "STOCK")
+@Table(name = "stock")
 @Entity
 public class Stock {
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -26,11 +26,11 @@ spring:
 #    username: root
 #    password: 1234
 #    driver-class-name: com.mysql.cj.jdbc.Driver
-
+#
 #  jpa:
 #    database-platform: org.hibernate.dialect.MySQL8Dialect
 #    hibernate:
-#      ddl-auto: validate
+#      ddl-auto: create-drop
 #    properties:
 #      hibernate:
 #        show_sql: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,6 +4,7 @@ spring:
       enabled: true
       path: /h2-console
 
+# H2 환경 변수
   datasource:
     url: jdbc:h2:mem:testdb;MODE=MySQL;
     driver-class-name: org.h2.Driver
@@ -18,6 +19,23 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+
+# MySQL 환경 변수
+#  datasource:
+#    url: jdbc:mysql://127.0.0.1:3306/wiseshop_test?rewriteBatchedStatements=true&profileSQL=true&logger=Slf4JLogger&maxQuerySizeToLog=999999
+#    username: root
+#    password: 1234
+#    driver-class-name: com.mysql.cj.jdbc.Driver
+
+#  jpa:
+#    database-platform: org.hibernate.dialect.MySQL8Dialect
+#    hibernate:
+#      ddl-auto: validate
+#    properties:
+#      hibernate:
+#        show_sql: true
+#        format_sql: true
+
 toss:
   payments:
     secret-key: TOSS_SECRET_KEY


### PR DESCRIPTION
### 요약
100만건의 데이터 생성을 위한 API를 구현했습니다.

로컬에서 동작을 확인했고 데이터가 잘 저장되는 것도 확인했습니다!

### API 명세서 추가
1. /api/v1/test/generate/test-campaign

- 해당 API를 실행하면 발생하는 일
    1. 기존에 존재하던 데이터가 모두 사라집니다.
    2. 2명의 회원이 생성됩니다.
    3. 100만건의 캠페인이 생성됩니다.
        - 1번째로 생성된 회원은 100만건의 캠페인을 생성합니다.
    4. 100만건의 재고가 생성됩니다.
    5. 100만건의 상품이 생성됩니다.
        - 100만건의 재고와 각각 1:1로 매핑됩니다.
        - 1번째로 생성된 회원은 100만건의 상품을 생성합니다.
    6. 100만건의 주문이 생성됩니다.
        - 2번째로 생성된 회원은 100만건의 주문을 생성합니다.

- 소요 시간 : 약 1분

2. /api/v1/test/generate/test-member   

- 해당 API를 실행하면 발생하는 일
    1. 기존에 존재하던 데이터가 모두 사라집니다.
    3. 100만건의 회원 데이터가 생성됩니다.

- 소요 시간 : 약 13초

### 생성하면서 생긴 고민들
구현하면서 고민해봐야할 점들이 몇가지 생겼습니다.
1. 100만건의 캠페인 생성
   - 캠페인 생성 100만건을 하기 위해서 회원이 필요합니다.
   - 따라서 1명의 회원을 생성한 후 해당 회원이 100만건의 캠페인을 생성하도록 했습니다.
2. 100만건의 주문 생성
   - 주문 생성 100만건을 하기 위해서 재고, 상품 데이터가 필요합니다.
   - 두 객체는 공유되지 않기 때문에 각각 100만건을 생성해야합니다.
   - 따라서, 주문, 캠페인, 재고 이 3가지에 대한 데이터가 각각 100만건으로 총 300만건의 데이터가 생성됩니다.
4. 캠페인의 스케줄 상태변경은 어떻게?
   - 현재 INSERT BATCH 를 활용해서 데이터를 삽입하는데, 이는 스케줄러에 의해 상태변경을 진행해주지는 않습니다.
   - 스케줄러에 의해 상태변경을 하려면 스케줄러에 의해 100만건에 대한 스케줄을 등록해줘야 합니다.