### PR TITLE
feat: 세션 추적을 위한 리스너 추가

### DIFF
--- a/src/main/java/cholog/wiseshop/common/SessionListener.java
+++ b/src/main/java/cholog/wiseshop/common/SessionListener.java
@@ -1,0 +1,30 @@
+package cholog.wiseshop.common;
+
+import jakarta.servlet.http.HttpSessionEvent;
+import jakarta.servlet.http.HttpSessionListener;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SessionListener implements HttpSessionListener {
+
+    private static final Logger log = LoggerFactory.getLogger("GlobalExceptionHandler");
+    private static final AtomicInteger activeSessions = new AtomicInteger(0);
+
+    @Override
+    public void sessionCreated(HttpSessionEvent se) {
+        int currentSessions = activeSessions.incrementAndGet();
+        log.info("세션이 생성되었습니다. 세션 ID: {}", se.getSession().getId());
+
+        if (currentSessions % 5000 == 0) {
+            log.warn("세션 수 {}개 초과", currentSessions);
+        }
+    }
+
+    @Override
+    public void sessionDestroyed(HttpSessionEvent se) {
+        log.info("세션이 만료되거나 삭제되었습니다. 세션 ID: {}", se.getSession().getId());
+    }
+}


### PR DESCRIPTION
모니터링 환경이 구축되어있지 않기 때문에 로그레벨에서 추적하고자 했습니다.
세션이 생성될 떄마다 info로그를, 세션 5000개 마다 warn 로그를 찍어주는 방식을 구현해보았습니다.