### PR TITLE
fix: 캠페인 생성 시 캠페인의 상태에 따른 스케줄 등록 분기

### DIFF
--- a/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/service/CampaignService.java
@@ -66,7 +66,12 @@ public class CampaignService {
             stock,
             member
         ));
-        scheduler.scheduleCampaignToStart(campaign);
+        if (campaign.isWaiting()) {
+            scheduler.scheduleCampaignToStart(campaign);
+        }
+        else {
+            scheduler.scheduleCampaignToFinish(campaign);
+        }
         return CreateCampaignResponse.from(campaign.getId());
     }
 

--- a/src/main/java/cholog/wiseshop/common/ThreadTaskScheduler.java
+++ b/src/main/java/cholog/wiseshop/common/ThreadTaskScheduler.java
@@ -20,7 +20,8 @@ public class ThreadTaskScheduler {
     public ThreadTaskScheduler(
         ThreadPoolTaskScheduler scheduler,
         PlatformTransactionManager transactionManager,
-        CampaignRepository campaignRepository, ScheduledTaskStorage taskStorage) {
+        CampaignRepository campaignRepository, ScheduledTaskStorage taskStorage
+    ) {
         this.scheduler = scheduler;
         this.transactionTemplate = new TransactionTemplate(transactionManager);
         this.campaignRepository = campaignRepository;
@@ -46,6 +47,9 @@ public class ThreadTaskScheduler {
             campaignRepository.save(campaign);
             return null;
         });
-        scheduler.schedule(endCampaign, campaign.getEndDate().atZone(ZoneId.systemDefault()).toInstant());
+        ScheduledFuture<?> scheduledTask = scheduler.schedule(
+            endCampaign, campaign.getEndDate().atZone(ZoneId.systemDefault()).toInstant()
+        );
+        taskStorage.saveToStart(scheduledTask, campaign);
     }
 }


### PR DESCRIPTION
### 요약
- 캠페인 생성 시 캠페인의 상태에 따라 스케줄 등록을 분기했습니다.
- `WAITING` 시 캠페인 시작 스케줄 등록
- `IN_PROGRESS` 시 캠페인 종료 스케줄 등록
- 캠페인 종료 스케줄 태스크도 저장하도록 변경
   - why?
   - 캠페인이 `IN_PROGRESS` 상태로 생성되었을 때 종료 스케줄을 따로 등록하는데, 이때 캠페인이 삭제되면 해당 종료 스케줄에서 새로운 캠페인이 생성될 수도 있기 때문에 스케줄 태스크로 저장 후 캠페인 삭제 시 태스크 삭제가 같이 이루어지도록 수정