### PR TITLE
feat: 100만건의 테스트 데이터 생성 분리

### DIFF
--- a/src/main/java/cholog/wiseshop/api/testdata/controller/TestDataController.java
+++ b/src/main/java/cholog/wiseshop/api/testdata/controller/TestDataController.java
@@ -24,7 +24,13 @@ public class TestDataController {
 
     @PostMapping("/test/generate/test-campaign")
     public ResponseEntity<Void> generateCampaign() {
-        testDataService.generateTestData();
+        testDataService.generateTestCampaign();
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/test/generate/test-order")
+    public ResponseEntity<Void> generateOrder() {
+        testDataService.generateTestOrder();
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/cholog/wiseshop/api/testdata/controller/TestDataController.java
+++ b/src/main/java/cholog/wiseshop/api/testdata/controller/TestDataController.java
@@ -1,12 +1,14 @@
 package cholog.wiseshop.api.testdata.controller;
 
 import cholog.wiseshop.api.testdata.service.TestDataService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/test/generate")
 @RestController
 public class TestDataController {
 
@@ -16,7 +18,7 @@ public class TestDataController {
         this.testDataService = testDataService;
     }
 
-    @PostMapping("/test/generate/test-member")
+    @PostMapping("/test-member")
     public ResponseEntity<Void> generateTestMember() {
         testDataService.generateTestMember();
         return ResponseEntity.ok().build();
@@ -28,9 +30,15 @@ public class TestDataController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/test/generate/test-order")
+    @PostMapping("/test-order")
     public ResponseEntity<Void> generateOrder() {
         testDataService.generateTestOrder();
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/test-delete")
+    public ResponseEntity<Void> deleteTestData() {
+        testDataService.truncateAllData();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/cholog/wiseshop/api/testdata/service/TestDataService.java
+++ b/src/main/java/cholog/wiseshop/api/testdata/service/TestDataService.java
@@ -55,7 +55,7 @@ public class TestDataService {
         List<Object[]> memberBatch = new ArrayList<>();
 
         for (int i = 1; i <= size; i++) {
-            String email = "user" + i + "@test.com";
+            String email = "user" + i + "@example.com";
             String name = "user-" + UUID.randomUUID().toString().substring(0, 10);
             String password = "$2a$10$C5.NxKqjo2FC72RjSWJj1uNtCbia5ClEY5KhMtO7jEUN6N5s3.ZVu";
 

--- a/src/main/java/cholog/wiseshop/api/testdata/service/TestDataService.java
+++ b/src/main/java/cholog/wiseshop/api/testdata/service/TestDataService.java
@@ -1,7 +1,12 @@
 package cholog.wiseshop.api.testdata.service;
 
 import cholog.wiseshop.common.DatabaseCleaner;
+import cholog.wiseshop.common.ThreadTaskScheduler;
+import cholog.wiseshop.db.campaign.Campaign;
+import cholog.wiseshop.db.campaign.CampaignRepository;
 import cholog.wiseshop.db.campaign.CampaignState;
+import cholog.wiseshop.exception.WiseShopErrorCode;
+import cholog.wiseshop.exception.WiseShopException;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -17,15 +22,21 @@ public class TestDataService {
     private static final int ONE_HUNDRED_SIZE = 1_000_000;
     private static final int BATCH_SIZE = 10_000;
 
+    private final CampaignRepository campaignRepository;
     private final DatabaseCleaner databaseCleaner;
     private final JdbcTemplate jdbcTemplate;
+    private final ThreadTaskScheduler threadTaskScheduler;
 
     public TestDataService(
+        CampaignRepository campaignRepository,
         DatabaseCleaner databaseCleaner,
-        JdbcTemplate jdbcTemplate
+        JdbcTemplate jdbcTemplate,
+        ThreadTaskScheduler threadTaskScheduler
     ) {
         this.databaseCleaner = databaseCleaner;
         this.jdbcTemplate = jdbcTemplate;
+        this.threadTaskScheduler = threadTaskScheduler;
+        this.campaignRepository = campaignRepository;
     }
 
     public void generateTestMember() {
@@ -36,18 +47,22 @@ public class TestDataService {
     public void generateTestCampaign() {
         cleanAllData();
         generateTestMemberData(2);
-        generateTestCampaignData(ONE_HUNDRED_SIZE);
-        generateTestStockData(ONE_HUNDRED_SIZE);
+        generateTestCampaignData(ONE_HUNDRED_SIZE, 10, 0);
+        generateTestStockData(ONE_HUNDRED_SIZE, 10);
         generateTestProductData(ONE_HUNDRED_SIZE);
     }
 
     public void generateTestOrder() {
         cleanAllData();
         generateTestMemberData(ONE_HUNDRED_SIZE + 1);
-        generateTestCampaignData(1);
-        generateTestStockData(ONE_HUNDRED_SIZE);
-        generateTestProductData(ONE_HUNDRED_SIZE);
+        generateTestCampaignData(1, ONE_HUNDRED_SIZE * 2, 1_000_000);
+        generateTestStockData(1, ONE_HUNDRED_SIZE * 2);
+        generateTestProductData(1);
         generateTestOrderData(ONE_HUNDRED_SIZE);
+    }
+
+    public void truncateAllData() {
+        cleanAllData();
     }
 
     public void generateTestMemberData(int size) {
@@ -71,7 +86,7 @@ public class TestDataService {
         }
     }
 
-    public void generateTestCampaignData(int size) {
+    public void generateTestCampaignData(int size, int goalQuantity, int soldQuantity) {
         String sql = "INSERT INTO "
             + "campaign (start_date, end_date, goal_quantity, sold_quantity, state, member_id) "
             + "VALUES (?, ?, ?, ?, ?, ?)";
@@ -82,9 +97,7 @@ public class TestDataService {
             LocalDateTime now = LocalDateTime.now();
 
             LocalDateTime startDate = now.minusDays(1);
-            LocalDateTime endDate = now.plusMinutes(10);
-            int goalQuantity = 10;
-            int soldQuantity = 0;
+            LocalDateTime endDate = now.plusMinutes(1);
             String state = CampaignState.IN_PROGRESS.toString();
 
             campaignBatch.add(new Object[]{
@@ -106,13 +119,11 @@ public class TestDataService {
         }
     }
 
-    public void generateTestStockData(int size) {
+    public void generateTestStockData(int size, int totalQuantity) {
         String sql = "INSERT INTO stock (total_quantity) VALUES (?)";
         List<Object[]> stockBatch = new ArrayList<>();
 
         for (int i = 1; i <= size; i++) {
-            int totalQuantity = 100;
-
             stockBatch.add(new Object[]{totalQuantity});
 
             if (stockBatch.size() % BATCH_SIZE == 0) {
@@ -130,7 +141,7 @@ public class TestDataService {
             + "product (name, description, price, campaign_id, stock_id, member_id) "
             + "VALUES (?, ?, ?, ?, ?, ?)";
         List<Object[]> productBatch = new ArrayList<>();
-        Long campaignId = getTestDataIds("campaign", 1).getFirst();
+        List<Long> campaignIds = getTestDataIds("campaign", 1);
         List<Long> stockIds = getTestDataIds("stock", size);
         Long memberId = getTestDataIds("member", 1).getFirst();
 
@@ -139,6 +150,7 @@ public class TestDataService {
             String description = "Test Description" + UUID.randomUUID().toString().substring(0, 10);
             int price = (int) (Math.random() * 100) + 10000;
             Long stockId = stockIds.get(i - 1);
+            Long campaignId = campaignIds.get(i - 1);
 
             productBatch.add(new Object[]{
                 name,
@@ -163,13 +175,13 @@ public class TestDataService {
         String sql = "INSERT INTO "
             + "`order` (count, product_id, member_id, address, created_date, modified_date) "
             + "VALUES (?, ?, ?, ?, ?, ?)";
+
         List<Object[]> orderBatch = new ArrayList<>();
-        List<Long> productIds = getTestDataIds("product", size);
+        Long productId = getTestDataIds("product", size).getFirst();
         List<Long> memberIds = getTestDataIds("member", size + 1);
 
         for (int i = 1; i <= size; i++) {
             int count = 1;
-            Long productId = productIds.get(i - 1);
             Long memberId = memberIds.get(i);
             LocalDateTime createdDate = LocalDateTime.now();
             LocalDateTime modifiedDate = LocalDateTime.now();
@@ -188,6 +200,11 @@ public class TestDataService {
                 batchTestMember(sql, orderBatch);
             }
         }
+
+        Long campaignId = getTestDataIds("campaign", 1).getFirst();
+        Campaign campaign = campaignRepository.findById(campaignId)
+            .orElseThrow(() -> new WiseShopException(WiseShopErrorCode.CAMPAIGN_NOT_FOUND));
+        threadTaskScheduler.scheduleCampaignToFinish(campaign);
 
         if (!orderBatch.isEmpty()) {
             batchTestMember(sql, orderBatch);

--- a/src/main/java/cholog/wiseshop/api/testdata/service/TestDataService.java
+++ b/src/main/java/cholog/wiseshop/api/testdata/service/TestDataService.java
@@ -21,6 +21,7 @@ public class TestDataService {
 
     private static final int ONE_HUNDRED_SIZE = 1_000_000;
     private static final int BATCH_SIZE = 10_000;
+    private static final String TEST_PASSWORD = "$2a$10$C5.NxKqjo2FC72RjSWJj1uNtCbia5ClEY5KhMtO7jEUN6N5s3.ZVu";
 
     private final CampaignRepository campaignRepository;
     private final DatabaseCleaner databaseCleaner;
@@ -72,9 +73,8 @@ public class TestDataService {
         for (int i = 1; i <= size; i++) {
             String email = "user" + i + "@example.com";
             String name = "user-" + UUID.randomUUID().toString().substring(0, 10);
-            String password = "$2a$10$C5.NxKqjo2FC72RjSWJj1uNtCbia5ClEY5KhMtO7jEUN6N5s3.ZVu";
 
-            memberBatch.add(new Object[]{email, name, password});
+            memberBatch.add(new Object[]{email, name, TEST_PASSWORD});
 
             if (memberBatch.size() % BATCH_SIZE == 0) {
                 batchTestMember(sql, memberBatch);

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,7 +4,7 @@ spring:
       enabled: true
       path: /h2-console
 
-# H2 환경 변수
+  # H2 환경 변수
   datasource:
     url: jdbc:h2:mem:testdb;MODE=MySQL;
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
### 요약
1. 100만건의 회원 데이터 생성
   - `email` 형식은 `user1@example.com` 과 같다.
   - 배송지 데이터는 생성하지 않는다.
2. 100만건의 캠페인 데이터 생성
   - 회원 2명을 생성한다.
   - 첫번째 회원이 100만건의 캠페인을 생성한다.
   - 이떄, 연관되어 있는 재고, 상품도 같이 100만건을 생성한다.
   - 캠페인의 스케줄 등록은 따로 되지 않는다.
3. 100만건의 주문 데이터 생성
   - 회원 100만 + 1 건을 생성한다.
   - 첫번째 회원은 1건의 캠페인을 생성한다.
   - 캠페인의 상태가 1분뒤에 변경되도록 스케줄을 등록한다.
   - 남은 100만 회원은 캠페인에서 각자 1개씩 주문을 생성하도록 한다.
--- 
+ 데이터 전체 삭제 api 추가