### PR TITLE
feat: 상품 이름으로 검색하여 페이징 처리하는 API 구현

### DIFF
--- a/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
+++ b/src/main/java/cholog/wiseshop/api/campaign/controller/CampaignController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/v1/campaigns")
@@ -30,7 +31,7 @@ public class CampaignController {
 
     @PostMapping
     public ResponseEntity<CreateCampaignResponse> createCampaigns(@Auth Member member,
-        @RequestBody CreateCampaignRequest request) {
+                                                                  @RequestBody CreateCampaignRequest request) {
         var response = campaignService.createCampaign(request, member, LocalDateTime.now());
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
@@ -50,6 +51,14 @@ public class CampaignController {
     @GetMapping("/members")
     public ResponseEntity<List<MemberCampaignResponse>> readMemberCampaign(@Auth Member member) {
         List<MemberCampaignResponse> response = campaignService.readMemberCampaign(member);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<ReadCampaignResponse>> searchCampaigns(@RequestParam String keyword,
+                                                                      @RequestParam int page,
+                                                                      @RequestParam int size) {
+        List<ReadCampaignResponse> response = campaignService.searchByProductName(keyword, page, size);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/cholog/wiseshop/db/product/ProductRepository.java
+++ b/src/main/java/cholog/wiseshop/db/product/ProductRepository.java
@@ -17,8 +17,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     List<Product> findAllByOwnerId(Long memberId);
 
-//    Page<Product> findByNameContaining(String keyword, Pageable pageable);
-
     @Query(value = "SELECT p FROM Product p JOIN FETCH p.stock JOIN FETCH p.campaign WHERE p.name LIKE %:keyword%",
         countQuery = "SELECT COUNT(p) FROM Product p WHERE p.name LIKE %:keyword%")
     Page<Product> findByNameContaining(String keyword, Pageable pageable);

--- a/src/main/java/cholog/wiseshop/db/product/ProductRepository.java
+++ b/src/main/java/cholog/wiseshop/db/product/ProductRepository.java
@@ -17,5 +17,9 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     List<Product> findAllByOwnerId(Long memberId);
 
+//    Page<Product> findByNameContaining(String keyword, Pageable pageable);
+
+    @Query(value = "SELECT p FROM Product p JOIN FETCH p.stock JOIN FETCH p.campaign WHERE p.name LIKE %:keyword%",
+        countQuery = "SELECT COUNT(p) FROM Product p WHERE p.name LIKE %:keyword%")
     Page<Product> findByNameContaining(String keyword, Pageable pageable);
 }

--- a/src/main/java/cholog/wiseshop/db/product/ProductRepository.java
+++ b/src/main/java/cholog/wiseshop/db/product/ProductRepository.java
@@ -2,6 +2,8 @@ package cholog.wiseshop.db.product;
 
 import cholog.wiseshop.db.campaign.Campaign;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,4 +16,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> findAllByCampaign(Campaign campaign);
 
     List<Product> findAllByOwnerId(Long memberId);
+
+    Page<Product> findByNameContaining(String keyword, Pageable pageable);
 }

--- a/src/test/java/cholog/wiseshop/domain/CampaignServiceTest.java
+++ b/src/test/java/cholog/wiseshop/domain/CampaignServiceTest.java
@@ -311,4 +311,31 @@ public class CampaignServiceTest extends BaseTest {
             assertThat(response).hasSize(2);
         }
     }
+
+    @Nested
+    class 캠페인을_상품이름으로_검색한다 {
+
+        @Test
+        void 캠페인_상품이름으로_검색() {
+            // given
+            Member member = memberRepository.save(MemberFixture.최준호());
+            Campaign campaign = campaignRepository.save(CampaignFixture.진행중인_보약_캠페인(member));
+            Stock stock = new Stock(20);
+            stockRepository.save(stock);
+            productRepository.save(
+                ProductFixture.재고가_설정된_이름있는_캠페인의_보약(campaign, stock, member, "아주 좋은 보약"));
+
+            Campaign campaign2 = campaignRepository.save(CampaignFixture.진행중인_보약_캠페인(member));
+            Stock stock2 = new Stock(30);
+            stockRepository.save(stock2);
+            productRepository.save(
+                ProductFixture.재고가_설정된_이름있는_캠페인의_보약(campaign2, stock2, member, "아주 나쁜 보약"));
+
+            // when
+            List<ReadCampaignResponse> response = campaignService.searchByProductName("좋은", 0, 10);
+
+            // then
+            assertThat(response).hasSize(1);
+        }
+    }
 }

--- a/src/test/java/cholog/wiseshop/fixture/ProductFixture.java
+++ b/src/test/java/cholog/wiseshop/fixture/ProductFixture.java
@@ -18,6 +18,20 @@ public class ProductFixture {
             .build();
     }
 
+    public static Product 재고가_설정된_이름있는_캠페인의_보약(
+        Campaign campaign,
+        Stock stock,
+        Member owner,
+        String name) {
+        return Product.builder()
+            .name(name)
+            .campaign(campaign)
+            .price(1000)
+            .stock(stock)
+            .owner(owner)
+            .build();
+    }
+
     public static Product 재고가_설정된_캠페인의_보약(Campaign campaign, Stock stock, Member owner) {
         return Product.builder()
             .campaign(campaign)


### PR DESCRIPTION
## 요약
- Pageable + Spring Data JPA 적용
- 캠페인 검색 API : `GET /campaigns/search?keyword=보약&size=10&page=0`
  - 쿼리 파라미터로 `keyword`, `size`, `page` 입력 시, 해당 값을 토대로 페이징 처리